### PR TITLE
Trigger Socket manifest scan

### DIFF
--- a/.github/workflows/socket.yml
+++ b/.github/workflows/socket.yml
@@ -3,7 +3,6 @@ name: Socket Security
 on:
   pull_request:
     paths:
-      - .github/workflows/socket.yml
       - package.json
       - package-lock.json
       - worker/package.json

--- a/.github/workflows/socket.yml
+++ b/.github/workflows/socket.yml
@@ -15,6 +15,9 @@ on:
       - package-lock.json
       - worker/package.json
       - worker/package-lock.json
+  schedule:
+    # 03:00 UTC is 11:00 PM in America/New_York during daylight saving time.
+    - cron: '0 3 * * *'
   workflow_dispatch:
 
 concurrency:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "autodoc",
-  "version": "0.1.24",
+  "version":  "0.1.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
## Summary
- remove the temporary Socket workflow bootstrap trigger
- make a no-op package-lock.json whitespace change to trigger a real manifest-backed Socket scan

## Testing
- YAML parsed locally
- package-lock JSON parsed locally
