### PR TITLE
Derive release version from Git tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,17 @@ jobs:
           node-version: 20
           cache: npm
 
+      - name: Resolve release metadata
+        if: startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch' && inputs.release_tag != '')
+        id: release_meta
+        shell: bash
+        run: |
+          raw_tag="${{ inputs.release_tag != '' && inputs.release_tag || github.ref_name }}"
+          release_tag="${raw_tag#refs/tags/}"
+          release_version="${release_tag#v}"
+          echo "release_tag=$release_tag" >> "$GITHUB_OUTPUT"
+          echo "release_version=$release_version" >> "$GITHUB_OUTPUT"
+
       - name: Install dependencies
         run: npm ci
 
@@ -82,7 +93,10 @@ jobs:
           APPLE_ID: ${{ secrets.DD_APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.DD_APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.DD_APPLE_TEAM }}
-        run: npm run build:mac
+        run: |
+          npm run prepare:macos-whisper-runtime
+          npm run build
+          npx electron-builder --mac --publish never "-c.extraMetadata.version=${{ steps.release_meta.outputs.release_version }}"
 
       - name: Build macOS artifacts (signed, no notarization)
         if: github.event_name == 'push' && github.ref_type == 'branch'
@@ -103,7 +117,7 @@ jobs:
         if: (startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch' && inputs.release_tag != '')) && success()
         uses: actions/upload-artifact@v4
         with:
-          name: release-macos-${{ inputs.release_tag != '' && inputs.release_tag || github.ref_name }}
+          name: release-macos-${{ steps.release_meta.outputs.release_tag }}
           path: |
             dist/*.dmg
             dist/*.zip
@@ -130,6 +144,17 @@ jobs:
         with:
           node-version: 20
           cache: npm
+
+      - name: Resolve release metadata
+        if: startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch' && inputs.release_tag != '')
+        id: release_meta
+        shell: bash
+        run: |
+          raw_tag="${{ inputs.release_tag != '' && inputs.release_tag || github.ref_name }}"
+          release_tag="${raw_tag#refs/tags/}"
+          release_version="${release_tag#v}"
+          echo "release_tag=$release_tag" >> "$GITHUB_OUTPUT"
+          echo "release_version=$release_version" >> "$GITHUB_OUTPUT"
 
       - name: Install dependencies
         run: npm ci
@@ -224,7 +249,9 @@ jobs:
           SM_CLIENT_CERT_PASSWORD: ${{ secrets.DD_SM_CLIENT_CERT_PASSWORD }}
           SM_KEYPAIR_ALIAS: ${{ secrets.DD_SM_KEYPAIR_ALIAS }}
           SM_LOG_LEVEL: TRACE
-        run: npm run build:win
+        run: |
+          npm run build
+          npx electron-builder --win --publish never "-c.extraMetadata.version=${{ steps.release_meta.outputs.release_version }}"
 
       - name: Verify Windows signatures
         if: startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch' && inputs.release_tag != '')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -345,7 +345,7 @@ jobs:
         if: (startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch' && inputs.release_tag != '')) && success()
         uses: actions/upload-artifact@v4
         with:
-          name: release-windows-${{ inputs.release_tag != '' && inputs.release_tag || github.ref_name }}
+          name: release-windows-${{ steps.release_meta.outputs.release_tag }}
           path: |
             dist/*-setup.exe
             dist/latest.yml
@@ -375,25 +375,35 @@ jobs:
       contents: write
 
     steps:
+      - name: Resolve release metadata
+        id: release_meta
+        shell: bash
+        run: |
+          raw_tag="${{ inputs.release_tag != '' && inputs.release_tag || github.ref_name }}"
+          release_tag="${raw_tag#refs/tags/}"
+          release_version="${release_tag#v}"
+          echo "release_tag=$release_tag" >> "$GITHUB_OUTPUT"
+          echo "release_version=$release_version" >> "$GITHUB_OUTPUT"
+
       - name: Download macOS release assets
         if: needs.build-mac.result == 'success'
         uses: actions/download-artifact@v4
         with:
-          name: release-macos-${{ inputs.release_tag != '' && inputs.release_tag || github.ref_name }}
+          name: release-macos-${{ steps.release_meta.outputs.release_tag }}
           path: release-assets/mac
 
       - name: Download Windows release assets
         if: (startsWith(github.ref, 'refs/tags/') || inputs.release_platform == 'all') && needs.build-win.result == 'success'
         uses: actions/download-artifact@v4
         with:
-          name: release-windows-${{ inputs.release_tag != '' && inputs.release_tag || github.ref_name }}
+          name: release-windows-${{ steps.release_meta.outputs.release_tag }}
           path: release-assets/win
 
       - name: Publish curated GitHub release assets
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-          RELEASE_TAG: ${{ inputs.release_tag != '' && inputs.release_tag || github.ref_name }}
+          RELEASE_TAG: ${{ steps.release_meta.outputs.release_tag }}
         run: |
           assets=(release-assets/mac/*)
           if [ -d release-assets/win ]; then
@@ -410,7 +420,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-          RELEASE_TAG: ${{ inputs.release_tag != '' && inputs.release_tag || github.ref_name }}
+          RELEASE_TAG: ${{ steps.release_meta.outputs.release_tag }}
         run: |
           release_json="$(gh api "repos/${GH_REPO}/releases/tags/${RELEASE_TAG}")"
           blockmap_ids="$(jq -r '.assets[] | select(.name | endswith(".blockmap")) | .id' <<<"$release_json")"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,8 +49,10 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch' && inputs.release_tag != '')
         id: release_meta
         shell: bash
+        env:
+          RAW_TAG: ${{ inputs.release_tag != '' && inputs.release_tag || github.ref_name }}
         run: |
-          raw_tag="${{ inputs.release_tag != '' && inputs.release_tag || github.ref_name }}"
+          raw_tag="$RAW_TAG"
           release_tag="${raw_tag#refs/tags/}"
           release_version="${release_tag#v}"
           echo "release_tag=$release_tag" >> "$GITHUB_OUTPUT"
@@ -149,8 +151,10 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch' && inputs.release_tag != '')
         id: release_meta
         shell: bash
+        env:
+          RAW_TAG: ${{ inputs.release_tag != '' && inputs.release_tag || github.ref_name }}
         run: |
-          raw_tag="${{ inputs.release_tag != '' && inputs.release_tag || github.ref_name }}"
+          raw_tag="$RAW_TAG"
           release_tag="${raw_tag#refs/tags/}"
           release_version="${release_tag#v}"
           echo "release_tag=$release_tag" >> "$GITHUB_OUTPUT"
@@ -378,8 +382,10 @@ jobs:
       - name: Resolve release metadata
         id: release_meta
         shell: bash
+        env:
+          RAW_TAG: ${{ inputs.release_tag != '' && inputs.release_tag || github.ref_name }}
         run: |
-          raw_tag="${{ inputs.release_tag != '' && inputs.release_tag || github.ref_name }}"
+          raw_tag="$RAW_TAG"
           release_tag="${raw_tag#refs/tags/}"
           release_version="${release_tag#v}"
           echo "release_tag=$release_tag" >> "$GITHUB_OUTPUT"

--- a/src/renderer/src/components/onboarding/ScreenPermissionStep.tsx
+++ b/src/renderer/src/components/onboarding/ScreenPermissionStep.tsx
@@ -9,6 +9,7 @@ export function ScreenPermissionStep({
 }) {
   const [granted, setGranted] = useState(false)
   const [opened, setOpened] = useState(false)
+  const [isRestoring, setIsRestoring] = useState(true)
 
   const clearOpenedState = useCallback(async () => {
     await window.electronAPI.invoke('prefs:set-onboarding-permission-settings-opened', 'screen', false)
@@ -38,14 +39,20 @@ export function ScreenPermissionStep({
     let cancelled = false
 
     const restoreStepState = async () => {
-      const wasOpened = await window.electronAPI.invoke(
-        'prefs:get-onboarding-permission-settings-opened',
-        'screen',
-      )
-      if (!cancelled) {
-        setOpened(wasOpened)
+      try {
+        const wasOpened = await window.electronAPI.invoke(
+          'prefs:get-onboarding-permission-settings-opened',
+          'screen',
+        )
+        if (!cancelled) {
+          setOpened(wasOpened)
+        }
+        await checkPermission(allowAutoAdvance)
+      } finally {
+        if (!cancelled) {
+          setIsRestoring(false)
+        }
       }
-      await checkPermission(allowAutoAdvance)
     }
 
     void restoreStepState()
@@ -110,7 +117,7 @@ export function ScreenPermissionStep({
           : 'AutoDoc uses screen recording permission to capture meeting visuals. macOS verifies system audio separately when a recording starts, so you can continue even if you skip this for now.'}
       </p>
 
-      {granted ? (
+      {isRestoring ? null : granted ? (
         <button
           onClick={() => void handleContinue()}
           className="px-8 py-3 bg-sage text-white rounded-[10px] text-[14px] font-semibold hover:opacity-90 transition-opacity"

--- a/src/renderer/src/components/onboarding/__tests__/ScreenPermissionStep.test.tsx
+++ b/src/renderer/src/components/onboarding/__tests__/ScreenPermissionStep.test.tsx
@@ -77,6 +77,19 @@ describe('ScreenPermissionStep', () => {
     )
   })
 
+  it('does not briefly show the enable CTA while restoring a granted permission state', async () => {
+    vi.mocked(window.electronAPI.invoke).mockImplementation((channel: string) => {
+      if (channel === 'prefs:get-onboarding-permission-settings-opened') return Promise.resolve(false)
+      if (channel === 'permissions:check') return Promise.resolve({ microphone: false, screen: true })
+      return Promise.resolve({})
+    })
+
+    render(<ScreenPermissionStep onNext={vi.fn()} allowAutoAdvance={false} />)
+
+    expect(screen.queryByText('Enable Screen Recording')).not.toBeInTheDocument()
+    expect(await screen.findByText('Continue →')).toBeInTheDocument()
+  })
+
   it('marks screen access granted after desktop capture succeeds and OS screen access is reported granted', async () => {
     const getUserMedia = vi.fn().mockResolvedValue({
       getTracks: () => [{ stop: vi.fn() }],
@@ -96,7 +109,7 @@ describe('ScreenPermissionStep', () => {
 
     render(<ScreenPermissionStep onNext={vi.fn()} />)
 
-    await userEvent.click(screen.getByText('Enable Screen Recording'))
+    await userEvent.click(await screen.findByRole('button', { name: 'Enable Screen Recording' }))
 
     await waitFor(() => {
       expect(screen.getByText('Continue →')).toBeInTheDocument()
@@ -133,7 +146,7 @@ describe('ScreenPermissionStep', () => {
 
     render(<ScreenPermissionStep onNext={vi.fn()} />)
 
-    await userEvent.click(screen.getByText('Enable Screen Recording'))
+    await userEvent.click(await screen.findByRole('button', { name: 'Enable Screen Recording' }))
 
     await waitFor(() => {
       expect(window.electronAPI.invoke).toHaveBeenCalledWith(
@@ -164,7 +177,7 @@ describe('ScreenPermissionStep', () => {
 
     render(<ScreenPermissionStep onNext={vi.fn()} />)
 
-    await userEvent.click(screen.getByText('Enable Screen Recording'))
+    await userEvent.click(await screen.findByRole('button', { name: 'Enable Screen Recording' }))
 
     await waitFor(() => {
       expect(window.electronAPI.invoke).toHaveBeenCalledWith(

--- a/src/renderer/src/pages/__tests__/Onboarding.test.tsx
+++ b/src/renderer/src/pages/__tests__/Onboarding.test.tsx
@@ -101,7 +101,7 @@ describe('Onboarding', () => {
     render(<Onboarding onComplete={vi.fn()} />)
 
     expect(await screen.findByRole('heading', { name: 'Screen Recording' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /^continue/i })).toBeInTheDocument()
+    expect(await screen.findByRole('button', { name: /^continue/i })).toBeInTheDocument()
     expect(screen.queryByRole('heading', { name: 'Connect Calendar' })).not.toBeInTheDocument()
   })
 


### PR DESCRIPTION
## Summary
- derive release metadata from the pushed tag or manual release input
- override Electron Builder app version for tagged macOS and Windows release builds
- keep branch builds using the checked-in `package.json` version

## Why
This lets release builds use the git tag as the source of truth for the app version, so cutting a release no longer requires a separate version-bump PR.

## Test plan
- merge this PR
- push a test tag on a known `main` commit
- verify the built app reports the tag-derived version in the UI and packaged metadata
- verify branch builds still use the checked-in package version