### PR TITLE
Clean up release CI warnings and verify Windows signing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
     if: github.event_name == 'push' || inputs.release_platform == 'mac' || inputs.release_platform == 'all'
     runs-on: macos-latest
     permissions:
-      contents: write
+      contents: read
     env:
       AUTODOC_SENTRY_DSN: ${{ secrets.AUTODOC_SENTRY_DSN }}
       VITE_POSTHOG_KEY: ${{ secrets.VITE_POSTHOG_KEY }}
@@ -134,7 +134,7 @@ jobs:
     if: github.event_name == 'push' || inputs.release_platform == 'all'
     runs-on: windows-2022
     permissions:
-      contents: write
+      contents: read
     env:
       AUTODOC_SENTRY_DSN: ${{ secrets.AUTODOC_SENTRY_DSN }}
       VITE_POSTHOG_KEY: ${{ secrets.VITE_POSTHOG_KEY }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -239,6 +239,47 @@ jobs:
           $smToolsDir | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           "SMCTL_PATH=$smctlPath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
+          $signToolCandidates = @()
+
+          $signToolCommand = Get-Command signtool.exe -ErrorAction SilentlyContinue
+          if ($signToolCommand) {
+            $signToolCandidates += $signToolCommand.Source
+          }
+
+          if (${env:ProgramFiles(x86)}) {
+            $windowsKitsRoot = Join-Path ${env:ProgramFiles(x86)} 'Windows Kits\10'
+            $signToolCandidates += Join-Path $windowsKitsRoot 'App Certification Kit\signtool.exe'
+
+            $windowsKitsBin = Join-Path $windowsKitsRoot 'bin'
+            if (Test-Path $windowsKitsBin) {
+              $signToolCandidates += Get-ChildItem -Path $windowsKitsBin -Filter signtool.exe -File -Recurse -ErrorAction SilentlyContinue |
+                Sort-Object FullName -Descending |
+                Select-Object -ExpandProperty FullName
+            }
+          }
+
+          $signToolPath = $signToolCandidates |
+            Where-Object { $_ -and (Test-Path $_) } |
+            Select-Object -Unique -First 1
+
+          if (-not $signToolPath) {
+            throw 'signtool.exe was not found on PATH or in the standard Windows SDK locations.'
+          }
+
+          Write-Host "Resolved signtool.exe to $signToolPath"
+          try {
+            $versionInfo = (Get-Item $signToolPath).VersionInfo
+            if ($versionInfo.FileVersion) {
+              Write-Host "signtool.exe file version: $($versionInfo.FileVersion)"
+            }
+          } catch {
+            Write-Warning "Unable to read signtool.exe file version: $($_.Exception.Message)"
+          }
+
+          $signToolDir = Split-Path -Parent $signToolPath
+          $signToolDir | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          "SIGNTOOL_PATH=$signToolPath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
       - name: Check DigiCert signing health
         if: startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch' && inputs.release_tag != '')
         shell: pwsh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,9 @@ on:
         default: ''
         type: string
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   build-mac:
     if: github.event_name == 'push' || inputs.release_platform == 'mac' || inputs.release_platform == 'all'
@@ -38,11 +41,11 @@ jobs:
       HUGGINGFACE_TOKEN: ${{ secrets.HUGGINGFACE_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6.4.0
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Resolve release metadata
@@ -106,7 +109,7 @@ jobs:
 
       - name: Upload macOS artifacts
         if: github.event_name == 'push' && github.ref_type == 'branch' && success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: autodoc-macos-${{ github.run_number }}
           path: |
@@ -117,7 +120,7 @@ jobs:
 
       - name: Upload macOS release assets
         if: (startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch' && inputs.release_tag != '')) && success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: release-macos-${{ steps.release_meta.outputs.release_tag }}
           path: |
@@ -140,11 +143,11 @@ jobs:
       HUGGINGFACE_TOKEN: ${{ secrets.HUGGINGFACE_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6.4.0
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Resolve release metadata
@@ -164,7 +167,12 @@ jobs:
         run: npm ci
 
       - name: Run bootstrap tests
-        run: npm run test:main:run -- src/main/services/__tests__/whisper-manager.test.ts
+        shell: pwsh
+        run: |
+          npm run test:main:run -- src/main/services/__tests__/whisper-manager.test.ts
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
 
       - name: Materialize DigiCert client certificate
         if: startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch' && inputs.release_tag != '')
@@ -178,7 +186,9 @@ jobs:
 
       - name: Setup DigiCert signing tools
         if: startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch' && inputs.release_tag != '')
-        uses: digicert/ssm-code-signing@v1.0.0
+        uses: digicert/code-signing-software-trust-action@v1.2.1
+        with:
+          use-github-caching-service: true
         env:
           SM_HOST: https://clientauth.one.digicert.com
           SM_API_KEY: ${{ secrets.DD_SM_API_KEY }}
@@ -324,7 +334,7 @@ jobs:
 
       - name: Upload DigiCert signing diagnostics
         if: (startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch' && inputs.release_tag != '')) && failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: digicert-signing-diagnostics-${{ github.run_number }}
           path: ${{ runner.temp }}/digicert-signing-diagnostics
@@ -337,7 +347,7 @@ jobs:
 
       - name: Upload Windows artifacts
         if: github.event_name == 'push' && github.ref_type == 'branch' && success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: autodoc-windows-${{ github.run_number }}
           path: |
@@ -347,7 +357,7 @@ jobs:
 
       - name: Upload Windows release assets
         if: (startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch' && inputs.release_tag != '')) && success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: release-windows-${{ steps.release_meta.outputs.release_tag }}
           path: |
@@ -393,14 +403,14 @@ jobs:
 
       - name: Download macOS release assets
         if: needs.build-mac.result == 'success'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
         with:
           name: release-macos-${{ steps.release_meta.outputs.release_tag }}
           path: release-assets/mac
 
       - name: Download Windows release assets
         if: (startsWith(github.ref, 'refs/tags/') || inputs.release_platform == 'all') && needs.build-win.result == 'success'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
         with:
           name: release-windows-${{ steps.release_meta.outputs.release_tag }}
           path: release-assets/win

--- a/src/main/services/__tests__/whisper-manager.test.ts
+++ b/src/main/services/__tests__/whisper-manager.test.ts
@@ -51,6 +51,7 @@ describe('WhisperManager', () => {
     vi.clearAllMocks()
     isPackaged = false
     delete process.env.AUTODOC_ALLOW_SYSTEM_RUNTIME_FALLBACK
+    process.env.AUTODOC_WINDOWS_TRANSCRIPTION_BACKEND = 'whisper-cpp'
     manager = new WhisperManager()
     mockAccess.mockResolvedValue(undefined)
     mockMkdtemp.mockResolvedValue('/mock/probe-dir')


### PR DESCRIPTION
## What changed
- pinned the Windows `whisper-manager` bootstrap test to `AUTODOC_WINDOWS_TRANSCRIPTION_BACKEND=whisper-cpp`
- upgraded the workflow to current GitHub-owned actions and moved the build jobs to Node 22
- enabled `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` to avoid deprecated Node 20 action-runtime warnings
- replaced `digicert/ssm-code-signing@v1.0.0` with `digicert/code-signing-software-trust-action@v1.2.1`
- made the Windows bootstrap test step fail the job when Vitest fails
- added explicit Windows signing verification so unsigned artifacts cannot silently ship
- resolved `signtool.exe` from the Windows SDK and added it to `GITHUB_PATH` before DigiCert signing

## Why
The release workflow had a mix of noisy and real CI issues:
- Windows bootstrap test failures were being printed but not failing the job
- older GitHub Actions usage was surfacing Node 20 deprecation warnings
- the old DigiCert action emitted a misleading Android build-tools annotation
- after tightening verification, we confirmed Windows signing could silently produce unsigned artifacts if `signtool.exe` was not on `PATH`

This change cleans up the warnings and makes the workflow fail loudly if signing or bootstrap validation actually breaks.

## Impact
- release runs now complete without the previous warning/error annotations
- Windows signing is now verified end to end instead of being assumed
- future CI failures in this area should be actionable instead of noisy

## Validation
- `npm run test:main:run -- src/main/services/__tests__/whisper-manager.test.ts`
- `git diff --check`
- real tag-triggered release run `#164`: https://github.com/DuetDisplay/AutoDoc-Local/actions/runs/25933178485
  - `build-win`: success, 0 annotations
  - `build-mac`: success, 0 annotations
  - `publish-release`: success, 0 annotations
