### PR TITLE
Fix sentry recovery flows and socket alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1010,72 +1010,6 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/@electron/windows-sign": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@electron/windows-sign/-/windows-sign-1.2.2.tgz",
-      "integrity": "sha512-dfZeox66AvdPtb2lD8OsIIQh12Tp0GNCRUDfBHIKGpbmopZto2/A8nSpYYLoedPIHpqkeblZ/k8OV0Gy7PYuyQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "cross-dirname": "^0.1.0",
-        "debug": "^4.3.4",
-        "fs-extra": "^11.1.1",
-        "minimist": "^1.2.8",
-        "postject": "^1.0.0-alpha.6"
-      },
-      "bin": {
-        "electron-windows-sign": "bin/electron-windows-sign.js"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
-    "node_modules/@electron/windows-sign/node_modules/fs-extra": {
-      "version": "11.3.4",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
-      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
-    "node_modules/@electron/windows-sign/node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@electron/windows-sign/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/@emnapi/runtime": {
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
@@ -3579,9 +3513,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
@@ -3591,13 +3525,12 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
+        "@protobufjs/aspromise": "^1.1.1"
       }
     },
     "node_modules/@protobufjs/float": {
@@ -3607,9 +3540,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
@@ -3625,9 +3558,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@rolldown/pluginutils": {
@@ -4438,6 +4371,70 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.2",
@@ -6611,15 +6608,6 @@
         "buffer": "^5.1.0"
       }
     },
-    "node_modules/cross-dirname": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/cross-dirname/-/cross-dirname-0.1.0.tgz",
-      "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -8268,9 +8256,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -11718,36 +11706,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/postject": {
-      "version": "1.0.0-alpha.6",
-      "resolved": "https://registry.npmjs.org/postject/-/postject-1.0.0-alpha.6.tgz",
-      "integrity": "sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "commander": "^9.4.0"
-      },
-      "bin": {
-        "postject": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/postject/node_modules/commander": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
-      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": "^12.20.0 || >=14"
-      }
-    },
     "node_modules/preact": {
       "version": "10.29.0",
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.0.tgz",
@@ -11892,22 +11850,22 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
-      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
+      "version": "7.5.9",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.9.tgz",
+      "integrity": "sha512-Od4muIm3HW1AouyHF5lONOf1FWo3hY1NbFDoy191X9GzhpgW1clCoaFjfVs2rKJNFYpTNJbje4cbAIDBZJ63ZA==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/codegen": "^2.0.5",
         "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/inquire": "^1.1.2",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
         "long": "^5.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "zustand": "^5.0.2"
   },
   "overrides": {
-    "protobufjs": "7.5.5"
+    "fast-uri": "3.1.2",
+    "protobufjs": "7.5.9"
   }
 }

--- a/src/main/services/__tests__/calendar-validity.test.ts
+++ b/src/main/services/__tests__/calendar-validity.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { CalendarManager } from '../calendar-manager'
+import { ReconnectRequiredCalendarAuthError } from '../calendar-error-classification'
 
 const { logAutodocFailure, captureMessage } = vi.hoisted(() => ({
   logAutodocFailure: vi.fn(),
@@ -121,7 +122,7 @@ describe('Calendar sync hardening', () => {
       fetchUpcomingEvents: vi
         .fn()
         .mockRejectedValue(
-          new Error(
+          new ReconnectRequiredCalendarAuthError(
             'Microsoft token refresh failed: 400 {"error":"invalid_client","error_description":"AADSTS7000215: Invalid client secret provided."}'
           )
         )
@@ -161,5 +162,41 @@ describe('Calendar sync hardening', () => {
         })
       })
     )
+  })
+
+  it('does not mark Google accounts as reconnect-required for generic auth error strings', async () => {
+    const manager = new CalendarManager()
+    const googleProvider = createProvider({
+      fetchUpcomingEvents: vi
+        .fn()
+        .mockRejectedValue(
+          new Error(
+            'Google token refresh failed: 400 {"error":"invalid_grant","error_description":"Token has been expired or revoked."}'
+          )
+        )
+    })
+
+    ;(manager as any).accounts = [
+      {
+        id: 'google-account-1',
+        provider: 'google',
+        email: 'user@gmail.com',
+        connectedAt: Date.now()
+      }
+    ]
+    ;(manager as any).providers = new Map([['google', googleProvider]])
+
+    await expect(manager.fetchAllUpcomingEvents()).resolves.toEqual([])
+    await expect(manager.fetchAllUpcomingEvents()).resolves.toEqual([])
+
+    expect(googleProvider.fetchUpcomingEvents).toHaveBeenCalledTimes(2)
+    expect((manager as any).accounts).toHaveLength(1)
+    expect((manager as any).accounts[0]).toEqual(
+      expect.not.objectContaining({
+        syncIssue: 'reconnect-required'
+      })
+    )
+    expect(captureMessage).not.toHaveBeenCalled()
+    expect(logAutodocFailure).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/main/services/__tests__/calendar-validity.test.ts
+++ b/src/main/services/__tests__/calendar-validity.test.ts
@@ -114,4 +114,52 @@ describe('Calendar sync hardening', () => {
       })
     )
   })
+
+  it('marks Microsoft accounts as reconnect-required after a non-transient auth failure', async () => {
+    const manager = new CalendarManager()
+    const microsoftProvider = createProvider({
+      fetchUpcomingEvents: vi
+        .fn()
+        .mockRejectedValue(
+          new Error(
+            'Microsoft token refresh failed: 400 {"error":"invalid_client","error_description":"AADSTS7000215: Invalid client secret provided."}'
+          )
+        )
+    })
+
+    ;(manager as any).accounts = [
+      {
+        id: 'microsoft-account-1',
+        provider: 'microsoft',
+        email: 'user@contoso.com',
+        connectedAt: Date.now()
+      }
+    ]
+    ;(manager as any).providers = new Map([['microsoft', microsoftProvider]])
+
+    await expect(manager.fetchAllUpcomingEvents()).resolves.toEqual([])
+    await expect(manager.fetchAllUpcomingEvents()).resolves.toEqual([])
+
+    expect(microsoftProvider.fetchUpcomingEvents).toHaveBeenCalledTimes(1)
+    expect((manager as any).accounts).toHaveLength(1)
+    expect((manager as any).accounts[0]).toEqual(
+      expect.objectContaining({
+        id: 'microsoft-account-1',
+        syncIssue: 'reconnect-required'
+      })
+    )
+    expect(logAutodocFailure).not.toHaveBeenCalled()
+    expect(captureMessage).toHaveBeenCalledTimes(1)
+    expect(captureMessage).toHaveBeenCalledWith(
+      'Calendar account requires reconnect',
+      expect.objectContaining({
+        area: 'calendar',
+        level: 'info',
+        tags: expect.objectContaining({
+          provider: 'microsoft',
+          calendar_sync_issue: 'reconnect-required'
+        })
+      })
+    )
+  })
 })

--- a/src/main/services/__tests__/calendar-validity.test.ts
+++ b/src/main/services/__tests__/calendar-validity.test.ts
@@ -1,6 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { CalendarManager } from '../calendar-manager'
-import { ReconnectRequiredCalendarAuthError } from '../calendar-error-classification'
+import {
+  ReconnectRequiredCalendarAuthError,
+  isReconnectRequiredMicrosoftAuthError
+} from '../calendar-error-classification'
 
 const { logAutodocFailure, captureMessage } = vi.hoisted(() => ({
   logAutodocFailure: vi.fn(),
@@ -39,6 +42,17 @@ function createProvider(overrides: Record<string, unknown> = {}) {
     ...overrides
   }
 }
+
+const fetchScenarios = [
+  {
+    label: 'upcoming events',
+    invoke: (manager: CalendarManager) => manager.fetchAllUpcomingEvents()
+  },
+  {
+    label: 'recent events',
+    invoke: (manager: CalendarManager) => manager.fetchAllRecentEvents()
+  }
+] as const
 
 describe('Calendar sync hardening', () => {
   beforeEach(() => {
@@ -104,7 +118,7 @@ describe('Calendar sync hardening', () => {
     expect(logAutodocFailure).not.toHaveBeenCalled()
     expect(captureMessage).toHaveBeenCalledTimes(1)
     expect(captureMessage).toHaveBeenCalledWith(
-      'Unsupported Microsoft mailbox disabled for calendar sync',
+      'Unsupported calendar account disabled for calendar sync',
       expect.objectContaining({
         area: 'calendar',
         level: 'info',
@@ -116,87 +130,107 @@ describe('Calendar sync hardening', () => {
     )
   })
 
-  it('marks Microsoft accounts as reconnect-required after a non-transient auth failure', async () => {
-    const manager = new CalendarManager()
-    const microsoftProvider = createProvider({
-      fetchUpcomingEvents: vi
+  it('does not classify invalid_client as a reconnect-required Microsoft auth failure', () => {
+    expect(
+      isReconnectRequiredMicrosoftAuthError(
+        new Error(
+          'Microsoft token refresh failed: 400 {"error":"invalid_client","error_description":"AADSTS7000215: Invalid client secret provided."}'
+        )
+      )
+    ).toBe(false)
+  })
+
+  it.each(fetchScenarios)(
+    'marks Microsoft accounts as reconnect-required after a recoverable auth failure while fetching $label',
+    async ({ invoke }) => {
+      const manager = new CalendarManager()
+      const fetchFailure = vi
         .fn()
         .mockRejectedValue(
           new ReconnectRequiredCalendarAuthError(
-            'Microsoft token refresh failed: 400 {"error":"invalid_client","error_description":"AADSTS7000215: Invalid client secret provided."}'
+            'Microsoft token refresh failed: 400 {"error":"interaction_required","error_description":"AADSTS50078: User interaction is required to renew consent."}'
           )
         )
-    })
-
-    ;(manager as any).accounts = [
-      {
-        id: 'microsoft-account-1',
-        provider: 'microsoft',
-        email: 'user@contoso.com',
-        connectedAt: Date.now()
-      }
-    ]
-    ;(manager as any).providers = new Map([['microsoft', microsoftProvider]])
-
-    await expect(manager.fetchAllUpcomingEvents()).resolves.toEqual([])
-    await expect(manager.fetchAllUpcomingEvents()).resolves.toEqual([])
-
-    expect(microsoftProvider.fetchUpcomingEvents).toHaveBeenCalledTimes(1)
-    expect((manager as any).accounts).toHaveLength(1)
-    expect((manager as any).accounts[0]).toEqual(
-      expect.objectContaining({
-        id: 'microsoft-account-1',
-        syncIssue: 'reconnect-required'
+      const microsoftProvider = createProvider({
+        fetchUpcomingEvents: fetchFailure,
+        fetchRecentEvents: fetchFailure
       })
-    )
-    expect(logAutodocFailure).not.toHaveBeenCalled()
-    expect(captureMessage).toHaveBeenCalledTimes(1)
-    expect(captureMessage).toHaveBeenCalledWith(
-      'Calendar account requires reconnect',
-      expect.objectContaining({
-        area: 'calendar',
-        level: 'info',
-        tags: expect.objectContaining({
+
+      ;(manager as any).accounts = [
+        {
+          id: 'microsoft-account-1',
           provider: 'microsoft',
-          calendar_sync_issue: 'reconnect-required'
-        })
-      })
-    )
-  })
+          email: 'user@contoso.com',
+          connectedAt: Date.now()
+        }
+      ]
+      ;(manager as any).providers = new Map([['microsoft', microsoftProvider]])
 
-  it('does not mark Google accounts as reconnect-required for generic auth error strings', async () => {
-    const manager = new CalendarManager()
-    const googleProvider = createProvider({
-      fetchUpcomingEvents: vi
+      await expect(invoke(manager)).resolves.toEqual([])
+      await expect(invoke(manager)).resolves.toEqual([])
+
+      expect(fetchFailure).toHaveBeenCalledTimes(1)
+      expect((manager as any).accounts).toHaveLength(1)
+      expect((manager as any).accounts[0]).toEqual(
+        expect.objectContaining({
+          id: 'microsoft-account-1',
+          syncIssue: 'reconnect-required'
+        })
+      )
+      expect(logAutodocFailure).not.toHaveBeenCalled()
+      expect(captureMessage).toHaveBeenCalledTimes(1)
+      expect(captureMessage).toHaveBeenCalledWith(
+        'Calendar account requires reconnect',
+        expect.objectContaining({
+          area: 'calendar',
+          level: 'info',
+          tags: expect.objectContaining({
+            provider: 'microsoft',
+            calendar_sync_issue: 'reconnect-required'
+          })
+        })
+      )
+    }
+  )
+
+  it.each(fetchScenarios)(
+    'does not mark Google accounts as reconnect-required for generic auth error strings while fetching $label',
+    async ({ invoke }) => {
+      const manager = new CalendarManager()
+      const fetchFailure = vi
         .fn()
         .mockRejectedValue(
           new Error(
             'Google token refresh failed: 400 {"error":"invalid_grant","error_description":"Token has been expired or revoked."}'
           )
         )
-    })
-
-    ;(manager as any).accounts = [
-      {
-        id: 'google-account-1',
-        provider: 'google',
-        email: 'user@gmail.com',
-        connectedAt: Date.now()
-      }
-    ]
-    ;(manager as any).providers = new Map([['google', googleProvider]])
-
-    await expect(manager.fetchAllUpcomingEvents()).resolves.toEqual([])
-    await expect(manager.fetchAllUpcomingEvents()).resolves.toEqual([])
-
-    expect(googleProvider.fetchUpcomingEvents).toHaveBeenCalledTimes(2)
-    expect((manager as any).accounts).toHaveLength(1)
-    expect((manager as any).accounts[0]).toEqual(
-      expect.not.objectContaining({
-        syncIssue: 'reconnect-required'
+      const googleProvider = createProvider({
+        fetchUpcomingEvents: fetchFailure,
+        fetchRecentEvents: fetchFailure
       })
-    )
-    expect(captureMessage).not.toHaveBeenCalled()
-    expect(logAutodocFailure).toHaveBeenCalledTimes(2)
-  })
+
+      ;(manager as any).accounts = [
+        {
+          id: 'google-account-1',
+          provider: 'google',
+          email: 'user@gmail.com',
+          connectedAt: Date.now()
+        }
+      ]
+      ;(manager as any).providers = new Map([['google', googleProvider]])
+
+      await expect(invoke(manager)).resolves.toEqual([])
+      await expect(invoke(manager)).resolves.toEqual([])
+
+      expect(fetchFailure).toHaveBeenCalledTimes(2)
+      expect((manager as any).accounts).toHaveLength(1)
+      expect((manager as any).accounts[0]).toEqual(
+        expect.not.objectContaining({
+          syncIssue: 'reconnect-required'
+        })
+      )
+      expect(captureMessage).not.toHaveBeenCalled()
+      expect(logAutodocFailure).toHaveBeenCalledTimes(2)
+    }
+  )
 })

--- a/src/main/services/__tests__/llm.test.ts
+++ b/src/main/services/__tests__/llm.test.ts
@@ -323,4 +323,124 @@ describe('OllamaProvider grounding', () => {
       })
     )
   })
+
+  it('falls back to a smaller Ollama context after a runner-stop 500 on a low-memory host', async () => {
+    const telemetry = vi.fn()
+    const adaptiveProvider = new OllamaProvider('http://localhost:11434', 'test-model', {
+      onTelemetry: telemetry
+    })
+    const requestContextTokens: number[] = []
+    ;(adaptiveProvider as any).getHostMemorySnapshot = () => ({ freeGiB: 0.66, totalGiB: 8 })
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (_url, init?: RequestInit) => {
+        const body = JSON.parse(String(init?.body ?? '{}')) as { options?: { num_ctx?: number } }
+        requestContextTokens.push(body.options?.num_ctx ?? 0)
+
+        if (requestContextTokens.length === 1) {
+          return new Response('{"error":"model runner has unexpectedly stopped"}', { status: 500 })
+        }
+
+        return new Response(
+          new ReadableStream({
+            start(controller) {
+              const encoder = new TextEncoder()
+              controller.enqueue(
+                encoder.encode(
+                  `${JSON.stringify({
+                    message: {
+                      content: JSON.stringify({
+                        decisions: [],
+                        action_items: [],
+                        information: [
+                          {
+                            topic: 'Planning',
+                            title: 'Launch plan confirmed',
+                            content: 'The launch plan was confirmed for next week.',
+                            sourceStartMs: 0,
+                            sourceEndMs: 0
+                          }
+                        ],
+                        discussion: [],
+                        status_updates: []
+                      })
+                    }
+                  })}\n`
+                )
+              )
+              controller.close()
+            }
+          }),
+          { status: 200 }
+        )
+      })
+    )
+
+    const result = await adaptiveProvider.summarize(
+      'meeting-low-ram-generic-500',
+      '[00:00] [Chris] The launch plan was confirmed for next week.',
+      undefined,
+      5
+    )
+
+    expect(result.information).toHaveLength(1)
+    expect(requestContextTokens).toEqual([
+      process.platform === 'win32' ? WINDOWS_CONTEXT_TOKENS : STANDARD_CONTEXT_TOKENS,
+      LOW_MEMORY_CONTEXT_TOKENS
+    ])
+    expect(telemetry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        meetingId: 'meeting-low-ram-generic-500',
+        event: 'ollama_low_memory_fallback_triggered',
+        properties: expect.objectContaining({
+          hostFreeMemoryGiB: 0.66,
+          hostTotalMemoryGiB: 8
+        })
+      })
+    )
+    expect(telemetry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'ollama_low_memory_fallback_succeeded'
+      })
+    )
+  })
+
+  it('does not force low-memory fallback for a runner-stop 500 on a healthy host', async () => {
+    const telemetry = vi.fn()
+    const adaptiveProvider = new OllamaProvider('http://localhost:11434', 'test-model', {
+      onTelemetry: telemetry
+    })
+    const requestContextTokens: number[] = []
+    ;(adaptiveProvider as any).getHostMemorySnapshot = () => ({ freeGiB: 12, totalGiB: 32 })
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (_url, init?: RequestInit) => {
+        const body = JSON.parse(String(init?.body ?? '{}')) as { options?: { num_ctx?: number } }
+        requestContextTokens.push(body.options?.num_ctx ?? 0)
+        return new Response('{"error":"model runner has unexpectedly stopped"}', { status: 500 })
+      })
+    )
+
+    await expect(
+      adaptiveProvider.summarize(
+        'meeting-healthy-host-generic-500',
+        '[00:00] [Chris] The launch plan was confirmed for next week.',
+        undefined,
+        5
+      )
+    ).rejects.toThrow('model runner has unexpectedly stopped')
+
+    expect(requestContextTokens).toEqual([
+      process.platform === 'win32' ? WINDOWS_CONTEXT_TOKENS : STANDARD_CONTEXT_TOKENS,
+      process.platform === 'win32' ? WINDOWS_CONTEXT_TOKENS : STANDARD_CONTEXT_TOKENS,
+      process.platform === 'win32' ? WINDOWS_CONTEXT_TOKENS : STANDARD_CONTEXT_TOKENS
+    ])
+    expect(telemetry).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'ollama_low_memory_fallback_triggered'
+      })
+    )
+  })
 })

--- a/src/main/services/__tests__/ollama-onboarding-install.test.ts
+++ b/src/main/services/__tests__/ollama-onboarding-install.test.ts
@@ -4,6 +4,7 @@ import { join } from 'path'
 import { tmpdir } from 'os'
 
 const originalPlatform = process.platform
+const originalTestUserDataDir = process.env.AUTODOC_TEST_USER_DATA_DIR
 
 function setPlatform(platform: NodeJS.Platform) {
   Object.defineProperty(process, 'platform', {
@@ -52,6 +53,11 @@ afterEach(() => {
   vi.doUnmock('electron')
   vi.doUnmock('child_process')
   vi.resetModules()
+  if (originalTestUserDataDir == null) {
+    delete process.env.AUTODOC_TEST_USER_DATA_DIR
+  } else {
+    process.env.AUTODOC_TEST_USER_DATA_DIR = originalTestUserDataDir
+  }
   setPlatform(originalPlatform)
 })
 
@@ -145,6 +151,7 @@ describe('Ollama onboarding dependency installation', () => {
     const installedDataDir = join(rootDir, 'app-data', 'AutoDoc', 'ollama-data')
 
     try {
+      delete process.env.AUTODOC_TEST_USER_DATA_DIR
       await mkdir(installedRuntimeDir, { recursive: true })
       await mkdir(installedDataDir, { recursive: true })
       await writeFile(join(installedRuntimeDir, 'ollama.exe'), 'binary')

--- a/src/main/services/__tests__/whisper-onboarding-install.test.ts
+++ b/src/main/services/__tests__/whisper-onboarding-install.test.ts
@@ -5,6 +5,7 @@ import { dirname, join } from 'path'
 import { tmpdir } from 'os'
 
 const originalPlatform = process.platform
+const originalTestUserDataDir = process.env.AUTODOC_TEST_USER_DATA_DIR
 
 function setPlatform(platform: NodeJS.Platform) {
   Object.defineProperty(process, 'platform', {
@@ -29,8 +30,11 @@ async function loadWhisperManager(
   vi.resetModules()
 
   const execSyncMock = vi.fn()
-  const execFileMock = vi.fn((_file, _args, _options, callback) => {
-    callback(null)
+  const execFileMock = vi.fn((...args: unknown[]) => {
+    const callback = args.at(-1)
+    if (typeof callback === 'function') {
+      callback(null)
+    }
     return {} as never
   })
 
@@ -69,6 +73,11 @@ afterEach(async () => {
   vi.doUnmock('ffmpeg-static')
   delete process.env.AUTODOC_ALLOW_SYSTEM_RUNTIME_FALLBACK
   delete process.env.AUTODOC_WINDOWS_TRANSCRIPTION_BACKEND
+  if (originalTestUserDataDir == null) {
+    delete process.env.AUTODOC_TEST_USER_DATA_DIR
+  } else {
+    process.env.AUTODOC_TEST_USER_DATA_DIR = originalTestUserDataDir
+  }
   vi.resetModules()
   setPlatform(originalPlatform)
 })
@@ -158,6 +167,7 @@ describe('Whisper onboarding dependency installation', () => {
     const installedModelsDir = join(rootDir, 'app-data', 'AutoDoc', 'models')
 
     try {
+      delete process.env.AUTODOC_TEST_USER_DATA_DIR
       await mkdir(installedModelsDir, { recursive: true })
       await writeFile(join(installedModelsDir, 'whisper-cli.exe'), 'whisper')
       await writeFile(join(installedModelsDir, 'ffmpeg.exe'), 'ffmpeg')

--- a/src/main/services/__tests__/whisper-onboarding-install.test.ts
+++ b/src/main/services/__tests__/whisper-onboarding-install.test.ts
@@ -6,6 +6,19 @@ import { tmpdir } from 'os'
 
 const originalPlatform = process.platform
 const originalTestUserDataDir = process.env.AUTODOC_TEST_USER_DATA_DIR
+type ExecFileCallback = (error: Error | null, stdout?: string, stderr?: string) => void
+
+function getExecFileCallback(
+  optionsOrCallback: unknown,
+  maybeCallback?: unknown
+): ExecFileCallback {
+  const callback = typeof optionsOrCallback === 'function' ? optionsOrCallback : maybeCallback
+  if (typeof callback !== 'function') {
+    throw new Error('Expected execFile callback in test')
+  }
+
+  return callback as ExecFileCallback
+}
 
 function setPlatform(platform: NodeJS.Platform) {
   Object.defineProperty(process, 'platform', {
@@ -830,7 +843,7 @@ describe('Whisper onboarding dependency installation', () => {
       await writeFile(join(manager.getModelsDir(), 'ggml.dll'), 'dll')
 
       execFileMock.mockImplementation((file, _args, optionsOrCallback, maybeCallback) => {
-        const callback = typeof optionsOrCallback === 'function' ? optionsOrCallback : maybeCallback
+        const callback = getExecFileCallback(optionsOrCallback, maybeCallback)
         if (file === manager.getWhisperPath()) {
           const err = new Error('Command failed: whisper probe timed out') as Error & {
             killed?: boolean
@@ -906,7 +919,7 @@ describe('Whisper onboarding dependency installation', () => {
       await writeFile(join(manager.getModelsDir(), 'ggml.dll'), 'dll')
 
       execFileMock.mockImplementation((file, _args, optionsOrCallback, maybeCallback) => {
-        const callback = typeof optionsOrCallback === 'function' ? optionsOrCallback : maybeCallback
+        const callback = getExecFileCallback(optionsOrCallback, maybeCallback)
         if (file === manager.getWhisperPath()) {
           const err = new Error('Command failed: whisper probe timed out') as Error & {
             killed?: boolean

--- a/src/main/services/calendar-error-classification.ts
+++ b/src/main/services/calendar-error-classification.ts
@@ -69,7 +69,6 @@ export function isReconnectRequiredMicrosoftAuthError(error: unknown): boolean {
   const message = getErrorMessage(error).toLowerCase()
 
   return [
-    'invalid_client',
     'invalid_grant',
     'interaction_required',
     'insufficient scopes',

--- a/src/main/services/calendar-error-classification.ts
+++ b/src/main/services/calendar-error-classification.ts
@@ -18,6 +18,16 @@ export class UnsupportedCalendarAccountError extends Error {
   }
 }
 
+export class ReconnectRequiredCalendarAuthError extends Error {
+  readonly reason: 'reconnect-required'
+
+  constructor(message: string, reason: 'reconnect-required' = 'reconnect-required') {
+    super(message)
+    this.name = 'ReconnectRequiredCalendarAuthError'
+    this.reason = reason
+  }
+}
+
 function getErrorMessage(error: unknown): string {
   if (error instanceof Error) {
     return error.message
@@ -55,10 +65,34 @@ export function isUnsupportedMicrosoftMailboxError(error: unknown): boolean {
   return message.includes('mailboxnotenabledforrestapi')
 }
 
+export function isReconnectRequiredMicrosoftAuthError(error: unknown): boolean {
+  const message = getErrorMessage(error).toLowerCase()
+
+  return [
+    'invalid_client',
+    'invalid_grant',
+    'interaction_required',
+    'insufficient scopes',
+    'insufficient scope',
+    'insufficient privileges',
+    'insufficient privileges to complete the operation',
+    'token is expired',
+    'access token has expired',
+    'invalidauthenticationtoken',
+    'error_access_denied'
+  ].some((pattern) => message.includes(pattern))
+}
+
 export function isUnsupportedCalendarAccountError(
   error: unknown
 ): error is UnsupportedCalendarAccountError {
   return error instanceof UnsupportedCalendarAccountError
+}
+
+export function isReconnectRequiredCalendarAuthError(
+  error: unknown
+): error is ReconnectRequiredCalendarAuthError {
+  return error instanceof ReconnectRequiredCalendarAuthError
 }
 
 export function isCalendarTransientError(error: unknown): error is CalendarTransientError {

--- a/src/main/services/calendar-manager.ts
+++ b/src/main/services/calendar-manager.ts
@@ -9,6 +9,8 @@ import { logAutodocFailure } from './autodoc-log'
 import { captureMessage } from './sentry-reporter'
 import {
   isTransientCalendarError,
+  isReconnectRequiredCalendarAuthError,
+  isReconnectRequiredMicrosoftAuthError,
   isUnsupportedMicrosoftMailboxError,
   isCalendarTransientError,
   isUnsupportedCalendarAccountError
@@ -145,9 +147,19 @@ export class CalendarManager {
           isUnsupportedCalendarAccountError(result.reason) ||
           isUnsupportedMicrosoftMailboxError(result.reason)
         ) {
-          await this.markAccountSyncIssue(account?.id, 'unsupported-mailbox')
+          await this.markAccountSyncIssue(account?.id, 'unsupported-mailbox', account?.provider)
           console.warn(
             `Disabled calendar sync for unsupported account ${account?.email ?? account?.provider ?? 'unknown'}`
+          )
+          continue
+        }
+        if (
+          isReconnectRequiredCalendarAuthError(result.reason) ||
+          isReconnectRequiredMicrosoftAuthError(result.reason)
+        ) {
+          await this.markAccountSyncIssue(account?.id, 'reconnect-required', account?.provider)
+          console.warn(
+            `Calendar reconnect required for ${account?.email ?? account?.provider ?? 'unknown'}`
           )
           continue
         }
@@ -197,9 +209,19 @@ export class CalendarManager {
           isUnsupportedCalendarAccountError(result.reason) ||
           isUnsupportedMicrosoftMailboxError(result.reason)
         ) {
-          await this.markAccountSyncIssue(account?.id, 'unsupported-mailbox')
+          await this.markAccountSyncIssue(account?.id, 'unsupported-mailbox', account?.provider)
           console.warn(
             `Disabled calendar sync for unsupported account ${account?.email ?? account?.provider ?? 'unknown'}`
+          )
+          continue
+        }
+        if (
+          isReconnectRequiredCalendarAuthError(result.reason) ||
+          isReconnectRequiredMicrosoftAuthError(result.reason)
+        ) {
+          await this.markAccountSyncIssue(account?.id, 'reconnect-required', account?.provider)
+          console.warn(
+            `Calendar reconnect required for ${account?.email ?? account?.provider ?? 'unknown'}`
           )
           continue
         }
@@ -274,7 +296,8 @@ export class CalendarManager {
 
   private async markAccountSyncIssue(
     accountId: string | undefined,
-    syncIssue: CalendarAccount['syncIssue']
+    syncIssue: CalendarAccount['syncIssue'],
+    provider: CalendarAccount['provider'] | undefined
   ): Promise<void> {
     if (!accountId) {
       return
@@ -295,11 +318,15 @@ export class CalendarManager {
 
     if (changed) {
       this.saveAccounts()
-      captureMessage('Unsupported Microsoft mailbox disabled for calendar sync', {
+      const message =
+        syncIssue === 'reconnect-required'
+          ? 'Calendar account requires reconnect'
+          : 'Unsupported Microsoft mailbox disabled for calendar sync'
+      captureMessage(message, {
         area: 'calendar',
         level: 'info',
         tags: {
-          provider: 'microsoft',
+          provider: provider ?? 'unknown',
           calendar_sync_issue: syncIssue ?? 'none'
         },
         extra: {

--- a/src/main/services/calendar-manager.ts
+++ b/src/main/services/calendar-manager.ts
@@ -314,7 +314,7 @@ export class CalendarManager {
       const message =
         syncIssue === 'reconnect-required'
           ? 'Calendar account requires reconnect'
-          : 'Unsupported Microsoft mailbox disabled for calendar sync'
+          : 'Unsupported calendar account disabled for calendar sync'
       captureMessage(message, {
         area: 'calendar',
         level: 'info',

--- a/src/main/services/calendar-manager.ts
+++ b/src/main/services/calendar-manager.ts
@@ -10,7 +10,6 @@ import { captureMessage } from './sentry-reporter'
 import {
   isTransientCalendarError,
   isReconnectRequiredCalendarAuthError,
-  isReconnectRequiredMicrosoftAuthError,
   isUnsupportedMicrosoftMailboxError,
   isCalendarTransientError,
   isUnsupportedCalendarAccountError
@@ -153,10 +152,7 @@ export class CalendarManager {
           )
           continue
         }
-        if (
-          isReconnectRequiredCalendarAuthError(result.reason) ||
-          isReconnectRequiredMicrosoftAuthError(result.reason)
-        ) {
+        if (isReconnectRequiredCalendarAuthError(result.reason)) {
           await this.markAccountSyncIssue(account?.id, 'reconnect-required', account?.provider)
           console.warn(
             `Calendar reconnect required for ${account?.email ?? account?.provider ?? 'unknown'}`
@@ -215,10 +211,7 @@ export class CalendarManager {
           )
           continue
         }
-        if (
-          isReconnectRequiredCalendarAuthError(result.reason) ||
-          isReconnectRequiredMicrosoftAuthError(result.reason)
-        ) {
+        if (isReconnectRequiredCalendarAuthError(result.reason)) {
           await this.markAccountSyncIssue(account?.id, 'reconnect-required', account?.provider)
           console.warn(
             `Calendar reconnect required for ${account?.email ?? account?.provider ?? 'unknown'}`

--- a/src/main/services/llm.ts
+++ b/src/main/services/llm.ts
@@ -343,10 +343,7 @@ export class OllamaProvider implements LLMProvider {
           if (lastError.message === 'SEGMENTATION_PREEMPTED') {
             throw lastError
           }
-          if (
-            this.isInsufficientSystemMemoryError(lastError.message) &&
-            this.contextTokens > LOW_MEMORY_CONTEXT_TOKENS
-          ) {
+          if (this.shouldEnableLowMemoryFallback(lastError.message) && this.contextTokens > LOW_MEMORY_CONTEXT_TOKENS) {
             lowMemoryFallbackActivated = true
             this.enableLowMemoryContext(meetingId, lastError, {
               chunkIndex: i + 1,
@@ -617,6 +614,28 @@ export class OllamaProvider implements LLMProvider {
       normalized.includes('ollama') &&
       normalized.includes('requires more system memory') &&
       normalized.includes('than is available')
+    )
+  }
+
+  private isLowMemoryRunnerStopError(message: string): boolean {
+    const normalized = message.toLowerCase()
+    if (
+      !normalized.includes('ollama returned 500') ||
+      !normalized.includes('model runner has unexpectedly stopped')
+    ) {
+      return false
+    }
+
+    const hostMemory = this.getHostMemorySnapshot()
+    return (
+      (hostMemory.freeGiB != null && hostMemory.freeGiB < LOW_MEMORY_FREE_GIB_THRESHOLD) ||
+      (hostMemory.totalGiB != null && hostMemory.totalGiB < LOW_MEMORY_TOTAL_GIB_THRESHOLD)
+    )
+  }
+
+  private shouldEnableLowMemoryFallback(message: string): boolean {
+    return (
+      this.isInsufficientSystemMemoryError(message) || this.isLowMemoryRunnerStopError(message)
     )
   }
 

--- a/src/main/services/microsoft-calendar.ts
+++ b/src/main/services/microsoft-calendar.ts
@@ -8,8 +8,10 @@ import type { CalendarProvider } from './calendar-types'
 import { logAutodocFailure } from './autodoc-log'
 import {
   CalendarTransientError,
+  ReconnectRequiredCalendarAuthError,
   UnsupportedCalendarAccountError,
   isTransientCalendarError,
+  isReconnectRequiredMicrosoftAuthError,
   isUnsupportedMicrosoftMailboxError
 } from './calendar-error-classification'
 
@@ -198,6 +200,11 @@ export class MicrosoftCalendarProvider implements CalendarProvider {
             'Microsoft mailbox is not supported by Microsoft Graph calendar APIs.'
           )
         }
+        if (isReconnectRequiredMicrosoftAuthError(error)) {
+          throw new ReconnectRequiredCalendarAuthError(
+            'Microsoft Outlook needs to be reconnected to resume calendar sync.'
+          )
+        }
         throw error
       }
 
@@ -291,6 +298,11 @@ export class MicrosoftCalendarProvider implements CalendarProvider {
             { cause: error }
           )
         }
+        if (isReconnectRequiredMicrosoftAuthError(error)) {
+          throw new ReconnectRequiredCalendarAuthError(
+            'Microsoft Outlook needs to be reconnected to resume calendar sync.'
+          )
+        }
         console.error('Microsoft token refresh failed:', responseText)
         logAutodocFailure({
           area: 'calendar',
@@ -319,6 +331,9 @@ export class MicrosoftCalendarProvider implements CalendarProvider {
           'Microsoft token refresh failed due to transient network conditions',
           { cause: err }
         )
+      }
+      if (err instanceof ReconnectRequiredCalendarAuthError) {
+        throw err
       }
       console.error('Microsoft token refresh error:', err)
       logAutodocFailure({

--- a/src/renderer/src/pages/Settings.test.tsx
+++ b/src/renderer/src/pages/Settings.test.tsx
@@ -157,6 +157,32 @@ describe('Settings', () => {
     ).toBeInTheDocument()
   })
 
+  it('shows an inline message when a Microsoft account needs to be reconnected', async () => {
+    installMockElectronApi({
+      'app:get-version': '0.1.11',
+      'updater:get-status': createUpdateStatus(),
+      'app:get-runtime-info': createRuntimeInfo(),
+      'app:get-storage-info': createStorageInfo(),
+      'prefs:get-analytics-consent': false,
+      'calendar:get-accounts': [
+        createCalendarAccount({
+          id: 'acct-microsoft',
+          provider: 'microsoft',
+          email: 'person@contoso.com',
+          syncIssue: 'reconnect-required'
+        })
+      ],
+      'calendar:get-events': []
+    })
+
+    render(<Settings />)
+
+    expect(await screen.findByText('person@contoso.com')).toBeInTheDocument()
+    expect(
+      screen.getByText('Microsoft Outlook needs to be reconnected to resume calendar sync.')
+    ).toBeInTheDocument()
+  })
+
   it('removes downloaded AI components from settings', async () => {
     let storageInfo = createStorageInfo()
 

--- a/src/renderer/src/pages/Settings.tsx
+++ b/src/renderer/src/pages/Settings.tsx
@@ -19,6 +19,9 @@ function getCalendarSyncIssueMessage(account: CalendarAccount): string | null {
   if (account.syncIssue === 'unsupported-mailbox') {
     return 'Calendar sync is unavailable for this Microsoft mailbox type.'
   }
+  if (account.syncIssue === 'reconnect-required') {
+    return 'Microsoft Outlook needs to be reconnected to resume calendar sync.'
+  }
 
   return null
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -49,7 +49,7 @@ export interface CalendarAccount {
   provider: 'google' | 'microsoft'
   email: string
   connectedAt: number
-  syncIssue?: 'unsupported-mailbox' | null
+  syncIssue?: 'unsupported-mailbox' | 'reconnect-required' | null
 }
 
 export interface CalendarEvent {


### PR DESCRIPTION
## What changed
- add a reconnect-required Microsoft calendar state for stale auth and scope failures
- broaden Ollama low-memory fallback for generic runner-stop 500s on constrained hosts
- patch Socket dependency overrides for protobufjs and fast-uri
- clean up onboarding reuse-path tests so they reliably exercise installed-app fallback behavior

## Validation
- npm run typecheck
- npm run test:run
- npm run test:main:run -- src/main/services/__tests__/calendar-validity.test.ts src/main/services/__tests__/llm.test.ts
- npm run test:run -- src/renderer/src/pages/Settings.test.tsx
- npm run test:pr:ai
- npm run test:pr:settings
- npm run test:main:run -- src/main/services/__tests__/ollama-onboarding-install.test.ts src/main/services/__tests__/whisper-onboarding-install.test.ts
- npm run test:main:run

## Notes
- full main-process suite now only has two unrelated pre-existing failures in src/main/services/__tests__/application-install.test.ts covering Windows downgrade handling