### PR TITLE
Fix Ask AI follow-up scoping and notes notification activation

### DIFF
--- a/src/main/__tests__/notification-window.test.ts
+++ b/src/main/__tests__/notification-window.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => {
+  const ipcHandlers = new Map<string, () => void>()
+  const windows: FakeNotificationWindow[] = []
+
+  class FakeNotificationWindow {
+    private listeners = new Map<string, () => void>()
+    destroyed = false
+    isDestroyed = vi.fn(() => this.destroyed)
+    showInactive = vi.fn()
+    loadURL = vi.fn()
+    close = vi.fn(() => {
+      this.destroyed = true
+      this.listeners.get('closed')?.()
+    })
+    webContents = {
+      executeJavaScript: vi.fn(() => Promise.resolve())
+    }
+
+    constructor() {
+      windows.push(this)
+    }
+
+    on(event: string, handler: () => void) {
+      this.listeners.set(event, handler)
+      return this
+    }
+
+    once(event: string, handler: () => void) {
+      this.listeners.set(event, handler)
+      return this
+    }
+  }
+
+  return {
+    FakeNotificationWindow,
+    ipcHandlers,
+    windows,
+    ipcOnce: vi.fn((channel: string, handler: () => void) => {
+      ipcHandlers.set(channel, handler)
+    }),
+    ipcRemoveListener: vi.fn((channel: string, handler: () => void) => {
+      if (ipcHandlers.get(channel) === handler) {
+        ipcHandlers.delete(channel)
+      }
+    })
+  }
+})
+
+vi.mock('electron', () => ({
+  BrowserWindow: mocks.FakeNotificationWindow,
+  screen: {
+    getPrimaryDisplay: () => ({
+      workArea: { x: 0, y: 0, width: 1440, height: 900 }
+    })
+  },
+  ipcMain: {
+    once: mocks.ipcOnce,
+    removeListener: mocks.ipcRemoveListener
+  }
+}))
+
+const { shouldSuppressNotificationActivation, showNotificationWindow } =
+  await import('../notification-window')
+
+function showTestNotification(options: Partial<Parameters<typeof showNotificationWindow>[0]> = {}) {
+  showNotificationWindow({
+    title: 'Notes Ready',
+    body: 'Notes are ready.',
+    primaryActionLabel: 'Open Notes',
+    onPrimaryAction: vi.fn(),
+    onDismiss: vi.fn(),
+    autoDismissMs: 30_000,
+    ...options
+  })
+}
+
+describe('notification window activation suppression', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.clearAllMocks()
+    mocks.ipcHandlers.clear()
+    mocks.windows.length = 0
+  })
+
+  afterEach(() => {
+    for (const window of mocks.windows) {
+      if (!window.destroyed) window.close()
+    }
+    vi.clearAllTimers()
+    vi.useRealTimers()
+  })
+
+  it('does not suppress app activation merely because a notification is visible', () => {
+    showTestNotification()
+
+    expect(shouldSuppressNotificationActivation()).toBe(false)
+  })
+
+  it('briefly suppresses app activation after notification dismiss', () => {
+    showTestNotification()
+
+    mocks.ipcHandlers.get('notification:dismiss')?.()
+
+    expect(shouldSuppressNotificationActivation()).toBe(true)
+
+    vi.advanceTimersByTime(1_001)
+
+    expect(shouldSuppressNotificationActivation()).toBe(false)
+  })
+
+  it('does not suppress app activation after the primary action', () => {
+    showTestNotification()
+
+    mocks.ipcHandlers.get('notification:primary-action')?.()
+
+    expect(shouldSuppressNotificationActivation()).toBe(false)
+  })
+})

--- a/src/main/__tests__/notification-window.test.ts
+++ b/src/main/__tests__/notification-window.test.ts
@@ -22,12 +22,12 @@ const mocks = vi.hoisted(() => {
       windows.push(this)
     }
 
-    on(event: string, handler: () => void) {
+    on(event: string, handler: () => void): this {
       this.listeners.set(event, handler)
       return this
     }
 
-    once(event: string, handler: () => void) {
+    once(event: string, handler: () => void): this {
       this.listeners.set(event, handler)
       return this
     }
@@ -61,10 +61,15 @@ vi.mock('electron', () => ({
   }
 }))
 
-const { shouldSuppressNotificationActivation, showNotificationWindow } =
-  await import('../notification-window')
+const {
+  resetNotificationActivationSuppressionForTests,
+  shouldSuppressNotificationActivation,
+  showNotificationWindow
+} = await import('../notification-window')
 
-function showTestNotification(options: Partial<Parameters<typeof showNotificationWindow>[0]> = {}) {
+function showTestNotification(
+  options: Partial<Parameters<typeof showNotificationWindow>[0]> = {}
+): void {
   showNotificationWindow({
     title: 'Notes Ready',
     body: 'Notes are ready.',
@@ -82,6 +87,7 @@ describe('notification window activation suppression', () => {
     vi.clearAllMocks()
     mocks.ipcHandlers.clear()
     mocks.windows.length = 0
+    resetNotificationActivationSuppressionForTests()
   })
 
   afterEach(() => {

--- a/src/main/ipc/__tests__/chat-ipc.test.ts
+++ b/src/main/ipc/__tests__/chat-ipc.test.ts
@@ -1,4 +1,8 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdtemp, mkdir, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { MeetingMetadata, MeetingSegments } from '../../../shared/types'
 
 vi.mock('electron', () => ({
   app: { getPath: vi.fn(() => '/tmp/autodoc-chat-ipc-test') },
@@ -18,9 +22,23 @@ import {
 } from '../chat-ipc'
 
 describe('chat meeting retrieval helpers', () => {
+  const tempDirs: string[] = []
+
   beforeEach(() => {
     vi.clearAllMocks()
   })
+
+  afterEach(async () => {
+    vi.restoreAllMocks()
+    await Promise.all(tempDirs.map((dir) => rm(dir, { recursive: true, force: true })))
+    tempDirs.length = 0
+  })
+
+  async function createTempRecordingsDir(): Promise<string> {
+    const dir = await mkdtemp(join(tmpdir(), 'autodoc-chat-ipc-'))
+    tempDirs.push(dir)
+    return dir
+  }
 
   it('drops generic filler terms from broad meeting questions', () => {
     expect(extractQuestionTerms('What happened in my stand up meetings this week?')).toEqual([
@@ -293,4 +311,126 @@ describe('chat meeting retrieval helpers', () => {
       content: 'You have 0 recordings.'
     })
   })
+
+  it('does not pin a new short content question to the previous exact-title recording', async () => {
+    const baseDir = await createTempRecordingsDir()
+    await createRecording(baseDir, 'slack-qa', {
+      startedAt: new Date(2026, 5, 1, 9, 23).getTime(),
+      sourceName: 'sqa-testing (Channel) - Duet Display - Slack',
+      notes: 'QA huddle notes about smoke testing the release candidate.'
+    })
+    await createRecording(baseDir, 'billing-review', {
+      startedAt: new Date(2026, 5, 1, 10, 30).getTime(),
+      sourceName: 'Billing Migration Review',
+      notes: 'Morgan owns the billing migration checklist and the due date is Wednesday morning.',
+      noteCategory: 'actionItems'
+    })
+
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as {
+        messages: Array<{ role: string; content: string }>
+      }
+      const context = body.messages.at(-1)?.content ?? ''
+      const answer = context.includes('Billing Migration Review')
+        ? 'billing-context'
+        : 'stale-slack-context'
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(
+            new TextEncoder().encode(`${JSON.stringify({ message: { content: answer } })}\n`)
+          )
+          controller.close()
+        }
+      })
+      return { ok: true, body: stream } as Response
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    registerChatIpc(
+      baseDir,
+      {
+        waitUntilReady: vi.fn(),
+        isServerRunning: vi.fn(),
+        getBaseUrl: () => 'http://localhost:11434'
+      },
+      { getModel: () => 'fake-model' } as never,
+      {
+        fetchAllRecentEvents: vi.fn().mockResolvedValue([]),
+        fetchAllUpcomingEvents: vi.fn().mockResolvedValue([])
+      } as never
+    )
+
+    const streamHandler = vi
+      .mocked(ipcMain.handle)
+      .mock.calls.find(([channel]) => channel === 'chat:send-stream')?.[1]
+    const sender = { id: 101, send: vi.fn() }
+
+    await streamHandler?.(
+      { sender } as never,
+      'req-exact',
+      'Summarize sqa-testing (Channel) - Duet Display - Slack'
+    )
+    await streamHandler?.({ sender } as never, 'req-billing', 'who owns billing migration')
+
+    expect(sender.send).toHaveBeenCalledWith('chat:done', {
+      requestId: 'req-billing',
+      content: expect.stringContaining('Morgan')
+    })
+    expect(sender.send).not.toHaveBeenCalledWith('chat:done', {
+      requestId: 'req-billing',
+      content: expect.stringContaining('sqa-testing')
+    })
+  })
 })
+
+async function createRecording(
+  baseDir: string,
+  id: string,
+  params: {
+    startedAt: number
+    sourceName: string
+    notes: string
+    noteCategory?: keyof MeetingSegments
+  }
+): Promise<void> {
+  const meetingDir = join(baseDir, id)
+  await mkdir(meetingDir, { recursive: true })
+  await writeFile(join(meetingDir, 'mic.webm'), '')
+
+  const metadata: MeetingMetadata = {
+    sourceName: params.sourceName,
+    startedAt: params.startedAt,
+    stoppedAt: params.startedAt + 30 * 60_000,
+    durationSeconds: 30 * 60
+  }
+  await writeFile(join(meetingDir, 'metadata.json'), JSON.stringify(metadata))
+  await writeFile(
+    join(meetingDir, 'segments.json'),
+    JSON.stringify(createSegments(params.notes, params.noteCategory))
+  )
+}
+
+function createSegments(content: string, noteCategory: keyof MeetingSegments = 'information') {
+  const segments: MeetingSegments = {
+    decisions: [],
+    actionItems: [],
+    information: [],
+    discussion: [],
+    statusUpdates: []
+  }
+  segments[noteCategory] = [
+    {
+      id: 'note-1',
+      meetingId: 'fixture',
+      category: noteCategory === 'actionItems' ? 'action_item' : 'information',
+      topic: 'QA',
+      title: 'Fixture note',
+      content,
+      assignee: noteCategory === 'actionItems' ? 'Morgan' : null,
+      deadline: noteCategory === 'actionItems' ? 'Wednesday morning' : null,
+      sourceStartMs: 0,
+      sourceEndMs: 10_000
+    }
+  ]
+  return segments
+}

--- a/src/main/ipc/chat-ipc.ts
+++ b/src/main/ipc/chat-ipc.ts
@@ -307,6 +307,7 @@ export function registerChatIpc(
     session: ChatConversationState
   ): Promise<PreparedChatContext | null> => {
     if (shouldStartNewConversationScope(question)) return null
+    if (hasFreshSearchTerms(normalizeRecordingSearchText(question))) return null
 
     if (asksForNotesInPreviousSet(question) && session.lastCalendarEvents.length > 0) {
       const meetingContext = await recordingIndex.buildNoteAvailabilityForCalendarEvents(
@@ -729,12 +730,7 @@ function shouldStartNewConversationScope(question: string): boolean {
 
 function shouldUseConversationScope(question: string): boolean {
   const normalized = normalizeRecordingSearchText(question)
-  return (
-    isRecordingContentQuestion(normalized) ||
-    isImplicitFollowUpQuestion(normalized) ||
-    hasContextReference(normalized) ||
-    isShortContextualQuestion(normalized)
-  )
+  return isImplicitFollowUpQuestion(normalized) || hasContextReference(normalized)
 }
 
 function hasContextReference(normalizedQuestion: string): boolean {
@@ -783,11 +779,55 @@ function extractOrdinalReference(question: string): number | null {
 }
 
 function isImplicitFollowUpQuestion(normalizedQuestion: string): boolean {
-  return (
+  if (
     /\b(anything else|what else|more|details|elaborate|what about that|that meeting|this meeting|it)\b/.test(
       normalizedQuestion
-    ) || normalizedQuestion.split(' ').filter(Boolean).length <= 4
+    )
   )
+    return true
+
+  return isShortContextualQuestion(normalizedQuestion) && !hasFreshSearchTerms(normalizedQuestion)
+}
+
+function hasFreshSearchTerms(normalizedQuestion: string): boolean {
+  const genericFollowUpTerms = new Set([
+    'action',
+    'actions',
+    'assigned',
+    'blocker',
+    'blockers',
+    'deadline',
+    'deadlines',
+    'decision',
+    'decisions',
+    'detail',
+    'details',
+    'due',
+    'item',
+    'items',
+    'more',
+    'next',
+    'note',
+    'notes',
+    'owner',
+    'owners',
+    'owns',
+    'recap',
+    'risk',
+    'risks',
+    'status',
+    'step',
+    'steps',
+    'summary',
+    'task',
+    'tasks',
+    'todo',
+    'todos',
+    'transcript',
+    'transcripts'
+  ])
+
+  return extractQuestionTerms(normalizedQuestion).some((term) => !genericFollowUpTerms.has(term))
 }
 
 function buildScopedQuestion(question: string, session: ChatConversationState): string {

--- a/src/main/notification-window.ts
+++ b/src/main/notification-window.ts
@@ -40,6 +40,10 @@ export function shouldSuppressNotificationActivation(): boolean {
   return false
 }
 
+export function resetNotificationActivationSuppressionForTests(): void {
+  suppressAppActivationUntil = 0
+}
+
 function clearAutoDismissTimer(): void {
   if (autoDismissTimer) {
     clearTimeout(autoDismissTimer)

--- a/src/main/notification-window.ts
+++ b/src/main/notification-window.ts
@@ -5,7 +5,6 @@ let notificationKind: NotificationKind | null = null
 let autoDismissTimer: ReturnType<typeof setTimeout> | null = null
 let cleanupListeners: (() => void) | null = null
 let suppressAppActivationUntil = 0
-let suppressAppActivationWhileVisible = false
 
 function escapeHtml(value: string): string {
   return value
@@ -26,20 +25,11 @@ interface NotificationOptions {
   onDismiss: () => void
   kind?: NotificationKind
   autoDismissMs?: number
-  suppressAppActivationWhileVisible?: boolean
 }
 
 export type NotificationKind = 'meeting-detection' | 'notes-ready'
 
 export function shouldSuppressNotificationActivation(): boolean {
-  if (
-    suppressAppActivationWhileVisible &&
-    notificationWindow &&
-    !notificationWindow.isDestroyed()
-  ) {
-    return true
-  }
-
   if (suppressAppActivationUntil > 0) {
     if (Date.now() <= suppressAppActivationUntil) {
       return true
@@ -93,7 +83,6 @@ export function showNotificationWindow(options: NotificationOptions): void {
   })
   notificationWindow = win
   notificationKind = options.kind ?? null
-  suppressAppActivationWhileVisible = options.suppressAppActivationWhileVisible ?? false
 
   const handlePrimaryAction = (): void => {
     try {
@@ -129,7 +118,6 @@ export function showNotificationWindow(options: NotificationOptions): void {
       clearAutoDismissTimer()
       notificationWindow = null
       notificationKind = null
-      suppressAppActivationWhileVisible = false
     }
   })
 

--- a/src/main/services/__tests__/notes-ready-notifier.test.ts
+++ b/src/main/services/__tests__/notes-ready-notifier.test.ts
@@ -88,8 +88,7 @@ describe('notes ready notifier', () => {
         bodyTitle: 'Weekly Sync',
         bodySuffix: 'notes are ready.',
         primaryActionLabel: 'Open Notes',
-        kind: 'notes-ready',
-        suppressAppActivationWhileVisible: true
+        kind: 'notes-ready'
       })
     )
     expect(mocks.encryptJSON).toHaveBeenCalledWith(
@@ -132,10 +131,8 @@ describe('notes ready notifier', () => {
     if (process.platform === 'darwin') {
       expect(mocks.appHide).toHaveBeenCalledTimes(1)
     }
-    expect(mocks.showNotificationWindow).toHaveBeenCalledWith(
-      expect.objectContaining({
-        suppressAppActivationWhileVisible: true
-      })
+    expect(mocks.showNotificationWindow.mock.calls[0]?.[0]).not.toHaveProperty(
+      'suppressAppActivationWhileVisible'
     )
   })
 

--- a/src/main/services/chat-retrieval.ts
+++ b/src/main/services/chat-retrieval.ts
@@ -2342,6 +2342,7 @@ function stripQuestionScaffolding(question: string): string {
     'responsible',
     'remember',
     'say',
+    'search',
     'should',
     'standup',
     'stand',
@@ -2360,6 +2361,7 @@ function stripQuestionScaffolding(question: string): string {
     'were',
     'week',
     'weeks',
+    'focus',
     'you',
     'yesterday'
   ])

--- a/src/main/services/notes-ready-notifier.ts
+++ b/src/main/services/notes-ready-notifier.ts
@@ -58,7 +58,6 @@ export async function notifyNotesReady(
       : {}),
     primaryActionLabel: 'Open Notes',
     kind: 'notes-ready',
-    suppressAppActivationWhileVisible: true,
     onPrimaryAction: () => {
       focusMainWindow()
       getMainWindow()?.webContents.send('notes:open-meeting', { meetingId })

--- a/src/renderer/src/pages/AskAI.test.tsx
+++ b/src/renderer/src/pages/AskAI.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { AskAI } from './AskAI'
@@ -52,6 +52,31 @@ describe('AskAI', () => {
       'chat:send-stream',
       expect.any(String),
       'What changed in onboarding?',
+      []
+    )
+  })
+
+  it('ignores rapid duplicate submits while the first request is starting', async () => {
+    const api = installMockElectronApi({
+      'ollama:check-status': true
+    })
+    api.setHandler('chat:send-stream', () => new Promise(() => {}))
+
+    render(<AskAI />)
+
+    const input = screen.getByPlaceholderText(/ask a question about your meetings/i)
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'Who owns billing migration?' } })
+      fireEvent.keyDown(input, { key: 'Enter' })
+      fireEvent.keyDown(input, { key: 'Enter' })
+    })
+
+    expect(window.electronAPI.invoke).toHaveBeenCalledTimes(2)
+    expect(window.electronAPI.invoke).toHaveBeenCalledWith('ollama:check-status')
+    expect(window.electronAPI.invoke).toHaveBeenCalledWith(
+      'chat:send-stream',
+      expect.any(String),
+      'Who owns billing migration?',
       []
     )
   })

--- a/src/renderer/src/pages/AskAI.tsx
+++ b/src/renderer/src/pages/AskAI.tsx
@@ -1,11 +1,21 @@
-import { useState, useRef, useEffect } from 'react'
+import { useState, useRef, useEffect, type KeyboardEvent, type ReactElement } from 'react'
 import { PageHeader } from '../components/PageHeader'
 import { useChatStore } from '../stores/chat'
 import { trackEvent } from '../services/analytics'
 import { recordDiagnosticAction } from '../services/diagnostic-trail'
 import type { ChatClarificationOption } from '../../../preload/ipc'
 
-export function AskAI() {
+let fallbackRequestIdCounter = 0
+
+function createChatRequestId(): string {
+  const randomId = globalThis.crypto?.randomUUID?.()
+  if (randomId) return randomId
+
+  fallbackRequestIdCounter += 1
+  return `chat-${fallbackRequestIdCounter}`
+}
+
+export function AskAI(): ReactElement {
   const { messages, addMessage, updateMessage, appendToMessage, clearMessages } = useChatStore()
   const [input, setInput] = useState('')
   const [loading, setLoading] = useState(false)
@@ -33,14 +43,12 @@ export function AskAI() {
     question: string
     displayQuestion: string
     selectedMeetingId?: string
-  }) => {
+  }): Promise<void> => {
     const question = params.question.trim()
     if (!question || loading || isSendingRef.current) return
     isSendingRef.current = true
     activeStreamCleanupRef.current?.()
-    const requestId =
-      globalThis.crypto?.randomUUID?.() ??
-      `chat-${Date.now()}-${Math.random().toString(36).slice(2)}`
+    const requestId = createChatRequestId()
     const assistantMessageId = `assistant-${requestId}`
     const history = messages
       .filter((message) => message.content.trim().length > 0)
@@ -121,7 +129,7 @@ export function AskAI() {
     }
   }
 
-  const handleSend = async () => {
+  const handleSend = async (): Promise<void> => {
     const question = input.trim()
     if (!question || loading) return
     setInput('')
@@ -131,7 +139,7 @@ export function AskAI() {
   const handleClarificationSelect = async (
     message: { originalQuestion?: string },
     option: ChatClarificationOption
-  ) => {
+  ): Promise<void> => {
     if (loading) return
     await sendChatRequest({
       question: message.originalQuestion ?? `Answer using ${option.title}`,
@@ -140,14 +148,14 @@ export function AskAI() {
     })
   }
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
+  const handleKeyDown = (e: KeyboardEvent): void => {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault()
       handleSend()
     }
   }
 
-  const handleNewChat = async () => {
+  const handleNewChat = async (): Promise<void> => {
     activeStreamCleanupRef.current?.()
     activeStreamCleanupRef.current = null
     isSendingRef.current = false

--- a/src/renderer/src/pages/AskAI.tsx
+++ b/src/renderer/src/pages/AskAI.tsx
@@ -13,6 +13,7 @@ export function AskAI() {
   const scrollRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
   const activeStreamCleanupRef = useRef<(() => void) | null>(null)
+  const isSendingRef = useRef(false)
 
   useEffect(() => {
     window.electronAPI.invoke('ollama:check-status').then(setOllamaReady)
@@ -34,7 +35,8 @@ export function AskAI() {
     selectedMeetingId?: string
   }) => {
     const question = params.question.trim()
-    if (!question || loading) return
+    if (!question || loading || isSendingRef.current) return
+    isSendingRef.current = true
     activeStreamCleanupRef.current?.()
     const requestId =
       globalThis.crypto?.randomUUID?.() ??
@@ -69,6 +71,7 @@ export function AskAI() {
       window.electronAPI.on('chat:done', (payload) => {
         if (payload.requestId !== requestId) return
         updateMessage(assistantMessageId, payload.content, payload.clarificationOptions)
+        isSendingRef.current = false
         setLoading(false)
         activeStreamCleanupRef.current?.()
         activeStreamCleanupRef.current = null
@@ -81,6 +84,7 @@ export function AskAI() {
           'Sorry, I had trouble answering that. Make sure Ollama is running and try again.'
         )
         console.error('Chat failed:', payload.error)
+        isSendingRef.current = false
         setLoading(false)
         activeStreamCleanupRef.current?.()
         activeStreamCleanupRef.current = null
@@ -109,6 +113,7 @@ export function AskAI() {
         'Sorry, I had trouble answering that. Make sure Ollama is running and try again.'
       )
       console.error('Chat failed:', err)
+      isSendingRef.current = false
       setLoading(false)
       activeStreamCleanupRef.current?.()
       activeStreamCleanupRef.current = null
@@ -145,6 +150,7 @@ export function AskAI() {
   const handleNewChat = async () => {
     activeStreamCleanupRef.current?.()
     activeStreamCleanupRef.current = null
+    isSendingRef.current = false
     clearMessages()
     setInput('')
     setLoading(false)


### PR DESCRIPTION
## Summary

Fixes two regressions reported in Linear:

- AD-83: prevents Ask AI follow-up scoping from pinning subsequent fresh-search questions to the previously selected recording, and adds a synchronous send guard so rapid duplicate submits do not enqueue repeated messages.
- AD-85: allows Dock activation while the notes-ready notification is visible, while still suppressing app activation for the short close-button dismissal path that was originally guarded.

## Root Cause

For AD-83, Ask AI treated broad/short later questions as conversation-scoped follow-ups too aggressively. The title-based recording lookup could succeed, but later unrelated questions inherited that prior recording scope. The retrieval scorer also considered scaffold terms from `Search focus:` as required subject tokens, which could incorrectly eliminate otherwise relevant meetings.

For AD-85, the notification window set app-activation suppression for the entire notification lifetime. That protected the notification close-button path, but it also blocked legitimate Dock activation until the notification disappeared.

## Validation

- `npm run test:main:run -- src/main/ipc/__tests__/chat-ipc.test.ts`
- `npm run test:run -- src/renderer/src/pages/AskAI.test.tsx`
- `npm run test:main:run -- src/main/__tests__/notification-window.test.ts src/main/services/__tests__/notes-ready-notifier.test.ts`
- `npm run typecheck:node`

Note: a broader main AI test slice still has date-sensitive fixture failures around `this week` now that the current date is June 1, 2026; the focused AD-83 and AD-85 tests pass.
