### PR TITLE
[codex] Fix managed Ollama runtime extraction

### DIFF
--- a/src/main/ipc/chat-ipc.ts
+++ b/src/main/ipc/chat-ipc.ts
@@ -3,7 +3,7 @@ import { join } from 'path'
 import type { OllamaProvider } from '../services/llm'
 import type { CalendarEvent } from '../../shared/types'
 import type { CalendarManager } from '../services/calendar-manager'
-import { logAutodocEvent } from '../services/autodoc-log'
+import { logAutodocEvent, logAutodocFailure } from '../services/autodoc-log'
 import {
   ChatRecordingIndex,
   type ChatClarificationOption,
@@ -536,9 +536,11 @@ export function registerChatIpc(
     ): Promise<void> => {
       const sender = event.sender
       const session = getChatSession(chatSessions, sender.id)
+      let normalizedHistoryLength = 0
 
       try {
         const normalizedHistory = normalizeChatHistory(history)
+        normalizedHistoryLength = normalizedHistory.length
         const { directAnswer, context, clarificationOptions } = await prepareChatContext(
           question,
           normalizedHistory,
@@ -572,6 +574,12 @@ export function registerChatIpc(
         })
         sender.send('chat:done', { requestId, content } satisfies ChatDonePayload)
       } catch (error) {
+        logChatFailure(error, {
+          requestId,
+          route: 'chat:send-stream',
+          questionLength: question.length,
+          historyCount: normalizedHistoryLength
+        })
         sender.send('chat:error', {
           requestId,
           error: error instanceof Error ? error.message : String(error)
@@ -591,9 +599,11 @@ export function registerChatIpc(
     ): Promise<void> => {
       const sender = event.sender
       const session = getChatSession(chatSessions, sender.id)
+      let normalizedHistoryLength = 0
 
       try {
         const normalizedHistory = normalizeChatHistory(history)
+        normalizedHistoryLength = normalizedHistory.length
         const meetingContext = await recordingIndex.buildContextForMeetingIds(
           `Use the selected meeting to answer this question: ${question}`,
           [meetingId],
@@ -643,6 +653,13 @@ export function registerChatIpc(
         })
         sender.send('chat:done', { requestId, content } satisfies ChatDonePayload)
       } catch (error) {
+        logChatFailure(error, {
+          requestId,
+          route: 'chat:select-recording-stream',
+          questionLength: question.length,
+          historyCount: normalizedHistoryLength,
+          selectedMeetingId: meetingId
+        })
         sender.send('chat:error', {
           requestId,
           error: error instanceof Error ? error.message : String(error)
@@ -650,6 +667,25 @@ export function registerChatIpc(
       }
     }
   )
+}
+
+function logChatFailure(
+  error: unknown,
+  context: {
+    requestId: string
+    route: 'chat:send-stream' | 'chat:select-recording-stream'
+    questionLength: number
+    historyCount: number
+    selectedMeetingId?: string
+  }
+): void {
+  logAutodocFailure({
+    area: 'chat',
+    message: 'Ask AI chat request failed',
+    error,
+    meetingId: context.selectedMeetingId,
+    context
+  })
 }
 
 function getChatSession(

--- a/src/main/services/__tests__/ollama-onboarding-install.test.ts
+++ b/src/main/services/__tests__/ollama-onboarding-install.test.ts
@@ -1,5 +1,5 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
-import { access, mkdtemp, mkdir, readFile, rm, writeFile } from 'fs/promises'
+import { afterEach, describe, expect, it, vi, type Mock } from 'vitest'
+import { access, chmod, mkdtemp, mkdir, readFile, rm, stat, writeFile } from 'fs/promises'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { LOW_SPEC_MAC_OLLAMA_MODEL } from '../../../shared/constants'
@@ -7,7 +7,19 @@ import { LOW_SPEC_MAC_OLLAMA_MODEL } from '../../../shared/constants'
 const originalPlatform = process.platform
 const originalTestUserDataDir = process.env.AUTODOC_TEST_USER_DATA_DIR
 
-function setPlatform(platform: NodeJS.Platform) {
+interface LoadedOllamaManager {
+  OllamaManager: typeof import('../ollama-manager').OllamaManager
+  clearDownloadedComponents: typeof import('../storage-manager').clearDownloadedComponents
+  execSyncMock: Mock
+  execFileMock: Mock
+  spawnMock: Mock
+}
+
+interface OllamaManagerPrivateAccess {
+  getOllamaDataDir(): string
+}
+
+function setPlatform(platform: NodeJS.Platform): void {
   Object.defineProperty(process, 'platform', {
     configurable: true,
     value: platform
@@ -18,7 +30,7 @@ async function loadOllamaManager(
   platform: 'darwin' | 'win32',
   rootDir: string,
   isPackaged = false
-) {
+): Promise<LoadedOllamaManager> {
   setPlatform(platform)
   vi.resetModules()
 
@@ -45,6 +57,7 @@ async function loadOllamaManager(
     OllamaManager: mod.OllamaManager,
     clearDownloadedComponents: storageMod.clearDownloadedComponents,
     execSyncMock,
+    execFileMock,
     spawnMock
   }
 }
@@ -85,6 +98,7 @@ describe('Ollama onboarding dependency installation', () => {
         const runtimeDir = join(rootDir, 'models', 'ollama-runtime')
         await mkdir(runtimeDir, { recursive: true })
         await writeFile(join(runtimeDir, 'ollama'), 'binary')
+        await writeFile(join(runtimeDir, 'llama-server'), 'binary')
         manager.emit('download-complete', 'ollama')
       })
 
@@ -107,6 +121,9 @@ describe('Ollama onboarding dependency installation', () => {
       await expect(
         access(join(rootDir, 'models', 'ollama-runtime', 'ollama'))
       ).resolves.toBeUndefined()
+      await expect(
+        access(join(rootDir, 'models', 'ollama-runtime', 'llama-server'))
+      ).resolves.toBeUndefined()
       await expect(access(join(rootDir, 'ollama-data', 'serve-ready.txt'))).resolves.toBeUndefined()
       await expect(access(join(rootDir, 'ollama-data', 'model-ready.txt'))).resolves.toBeUndefined()
       await expect(
@@ -120,6 +137,74 @@ describe('Ollama onboarding dependency installation', () => {
         'pull-complete'
       ])
       await expect(manager.isReady()).resolves.toBe(true)
+    } finally {
+      await rm(rootDir, { recursive: true, force: true })
+    }
+  })
+
+  it('extracts the complete macOS Ollama runtime archive including llama-server', async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), 'autodoc-ollama-mac-extract-'))
+
+    try {
+      const { OllamaManager, execFileMock, execSyncMock } = await loadOllamaManager(
+        'darwin',
+        rootDir,
+        true
+      )
+      execSyncMock.mockImplementation(() => {
+        throw new Error('system lookup should not be used in packaged mode')
+      })
+
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => new Response(new Uint8Array([1, 2, 3]), { status: 200 }))
+      )
+
+      execFileMock.mockImplementation(
+        async (command: string, args: string[], callback: (err: Error | null) => void) => {
+          expect(command).toBe('tar')
+          expect(args).toEqual([
+            'xzf',
+            join(rootDir, 'models', 'ollama-runtime', 'ollama-darwin.tgz'),
+            '-C',
+            join(rootDir, 'models', 'ollama-runtime')
+          ])
+          await writeFile(join(rootDir, 'models', 'ollama-runtime', 'ollama'), 'binary')
+          await writeFile(join(rootDir, 'models', 'ollama-runtime', 'llama-server'), 'binary')
+          callback(null)
+        }
+      )
+
+      const manager = new OllamaManager()
+      await manager.ensureReady()
+
+      await expect(
+        access(join(rootDir, 'models', 'ollama-runtime', 'ollama'))
+      ).resolves.toBeUndefined()
+      await expect(
+        access(join(rootDir, 'models', 'ollama-runtime', 'llama-server'))
+      ).resolves.toBeUndefined()
+      await expect(manager.isReady()).resolves.toBe(true)
+    } finally {
+      await rm(rootDir, { recursive: true, force: true })
+    }
+  })
+
+  it('treats a packaged macOS runtime without llama-server as not ready', async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), 'autodoc-ollama-mac-missing-sidecar-'))
+
+    try {
+      const { OllamaManager, execSyncMock } = await loadOllamaManager('darwin', rootDir, true)
+      execSyncMock.mockImplementation(() => {
+        throw new Error('system lookup should not be used in packaged mode')
+      })
+
+      const runtimeDir = join(rootDir, 'models', 'ollama-runtime')
+      await mkdir(runtimeDir, { recursive: true })
+      await writeFile(join(runtimeDir, 'ollama'), 'binary')
+
+      const manager = new OllamaManager()
+      await expect(manager.isReady()).resolves.toBe(false)
     } finally {
       await rm(rootDir, { recursive: true, force: true })
     }
@@ -141,6 +226,37 @@ describe('Ollama onboarding dependency installation', () => {
       await expect(
         access(join(rootDir, 'models', 'ollama-runtime', 'ollama'))
       ).resolves.toBeUndefined()
+      await expect(manager.isReady()).resolves.toBe(true)
+    } finally {
+      await rm(rootDir, { recursive: true, force: true })
+    }
+  })
+
+  it('marks copied macOS installed runtime sidecars executable', async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), 'autodoc-ollama-dev-mac-sidecar-'))
+    const installedRuntimeDir = join(rootDir, 'app-data', 'AutoDoc', 'models', 'ollama-runtime')
+    const runtimeDir = join(rootDir, 'models', 'ollama-runtime')
+
+    try {
+      delete process.env.AUTODOC_TEST_USER_DATA_DIR
+      await mkdir(installedRuntimeDir, { recursive: true })
+      await writeFile(join(installedRuntimeDir, 'ollama'), 'binary')
+      await writeFile(join(installedRuntimeDir, 'llama-server'), 'binary')
+      await chmod(join(installedRuntimeDir, 'ollama'), 0o644)
+      await chmod(join(installedRuntimeDir, 'llama-server'), 0o644)
+
+      const { OllamaManager, execSyncMock } = await loadOllamaManager('darwin', rootDir)
+      execSyncMock.mockImplementation(() => {
+        throw new Error('system lookup should not be needed when installed assets exist')
+      })
+
+      const manager = new OllamaManager()
+      await manager.ensureReady()
+
+      const ollamaMode = (await stat(join(runtimeDir, 'ollama'))).mode
+      const llamaServerMode = (await stat(join(runtimeDir, 'llama-server'))).mode
+      expect(ollamaMode & 0o111).not.toBe(0)
+      expect(llamaServerMode & 0o111).not.toBe(0)
       await expect(manager.isReady()).resolves.toBe(true)
     } finally {
       await rm(rootDir, { recursive: true, force: true })
@@ -273,7 +389,9 @@ describe('Ollama onboarding dependency installation', () => {
       await expect(
         access(join(rootDir, 'models', 'ollama-runtime', 'ollama.exe'))
       ).resolves.toBeUndefined()
-      expect((manager as any).getOllamaDataDir()).toBe(installedDataDir)
+      expect((manager as unknown as OllamaManagerPrivateAccess).getOllamaDataDir()).toBe(
+        installedDataDir
+      )
       await expect(manager.isReady()).resolves.toBe(true)
     } finally {
       await rm(rootDir, { recursive: true, force: true })
@@ -329,6 +447,7 @@ describe('Ollama onboarding dependency installation', () => {
       await mkdir(runtimeDir, { recursive: true })
       await mkdir(dataDir, { recursive: true })
       await writeFile(join(runtimeDir, 'ollama'), 'binary')
+      await writeFile(join(runtimeDir, 'llama-server'), 'binary')
       await writeFile(join(dataDir, 'model-ready.txt'), manager.getModel())
 
       await expect(manager.isReady()).resolves.toBe(true)
@@ -343,6 +462,7 @@ describe('Ollama onboarding dependency installation', () => {
         .mockImplementation(async () => {
           await mkdir(runtimeDir, { recursive: true })
           await writeFile(join(runtimeDir, 'ollama'), 'binary')
+          await writeFile(join(runtimeDir, 'llama-server'), 'binary')
         })
       const startSpy = vi.spyOn(manager, 'start').mockImplementation(async () => {
         await manager.ensureReady()
@@ -363,6 +483,7 @@ describe('Ollama onboarding dependency installation', () => {
       expect(startSpy).toHaveBeenCalledTimes(1)
       expect(pullSpy).toHaveBeenCalledTimes(1)
       await expect(access(join(runtimeDir, 'ollama'))).resolves.toBeUndefined()
+      await expect(access(join(runtimeDir, 'llama-server'))).resolves.toBeUndefined()
       await expect(access(join(dataDir, 'serve-ready.txt'))).resolves.toBeUndefined()
       await expect(access(join(dataDir, 'model-ready.txt'))).resolves.toBeUndefined()
       expect(execSyncMock).not.toHaveBeenCalled()

--- a/src/main/services/ollama-manager.ts
+++ b/src/main/services/ollama-manager.ts
@@ -13,6 +13,7 @@ import {
 import { getInstalledModelsDir, getInstalledOllamaDataDir } from './dev-runtime-paths'
 import { canUseSystemRuntimeFallback } from './runtime-policy'
 
+const OLLAMA_DOWNLOAD_VERSION = 'v0.30.0'
 const IS_WIN = process.platform === 'win32'
 
 const OLLAMA_PORT = 11435 // Use a non-default port to avoid conflicts with user's own Ollama
@@ -45,6 +46,7 @@ export class OllamaManager extends EventEmitter {
   private model: string
   private resolveModel: PreferredModelResolver | null
   private readyPromise: Promise<void> | null = null
+  private adoptedSystemRuntime = false
 
   constructor(modelOrOptions?: string | OllamaManagerOptions) {
     super()
@@ -136,6 +138,10 @@ export class OllamaManager extends EventEmitter {
     return join(this.getRuntimeDir(), IS_WIN ? 'ollama.exe' : 'ollama')
   }
 
+  private getLlamaServerPath(): string {
+    return join(this.getRuntimeDir(), 'llama-server')
+  }
+
   private getOllamaDataDir(): string {
     return this.getInstalledFallbackOllamaDataDir() ?? join(app.getPath('userData'), 'ollama-data')
   }
@@ -143,6 +149,9 @@ export class OllamaManager extends EventEmitter {
   async isReady(): Promise<boolean> {
     try {
       await access(this.getBinaryPath())
+      if (process.platform === 'darwin' && !this.adoptedSystemRuntime) {
+        await access(this.getLlamaServerPath())
+      }
       return true
     } catch {
       return false
@@ -185,6 +194,7 @@ export class OllamaManager extends EventEmitter {
         const systemBinary = this.findSystemOllama()
         if (systemBinary) {
           await copyFile(systemBinary, this.getBinaryPath())
+          this.adoptedSystemRuntime = true
           return
         }
       }
@@ -428,7 +438,7 @@ export class OllamaManager extends EventEmitter {
   }
 
   private async downloadBinaryWindows(runtimeDir: string): Promise<void> {
-    const url = 'https://github.com/ollama/ollama/releases/latest/download/ollama-windows-amd64.zip'
+    const url = `https://github.com/ollama/ollama/releases/download/${OLLAMA_DOWNLOAD_VERSION}/ollama-windows-amd64.zip`
     const zipPath = join(runtimeDir, 'ollama.zip')
 
     await this.downloadToFile(url, zipPath)
@@ -453,21 +463,26 @@ export class OllamaManager extends EventEmitter {
   }
 
   private async downloadBinaryUnix(runtimeDir: string): Promise<void> {
-    const platform = process.platform === 'darwin' ? 'darwin' : 'linux'
-    const url = `https://github.com/ollama/ollama/releases/latest/download/ollama-${platform}.tgz`
-    const tgzPath = join(runtimeDir, 'ollama.tgz')
+    if (process.platform !== 'darwin') {
+      throw new Error('Managed Ollama downloads are only supported on macOS and Windows')
+    }
 
-    await this.downloadToFile(url, tgzPath)
+    const archiveName = 'ollama-darwin.tgz'
+    const archivePath = join(runtimeDir, archiveName)
+    const url = `https://github.com/ollama/ollama/releases/download/${OLLAMA_DOWNLOAD_VERSION}/${archiveName}`
+
+    await this.downloadToFile(url, archivePath)
 
     await new Promise<void>((resolve, reject) => {
-      execFile('tar', ['xzf', tgzPath, '-C', runtimeDir, 'ollama'], (err) => {
+      execFile('tar', ['xzf', archivePath, '-C', runtimeDir], (err) => {
         if (err) reject(new Error(`Failed to extract Ollama: ${err.message}`))
         else resolve()
       })
     })
 
     await chmod(this.getBinaryPath(), 0o755)
-    await rm(tgzPath, { force: true })
+    await chmod(this.getLlamaServerPath(), 0o755)
+    await rm(archivePath, { force: true })
   }
 
   private async downloadToFile(url: string, destPath: string): Promise<void> {
@@ -531,7 +546,7 @@ export class OllamaManager extends EventEmitter {
       }
 
       await copyFile(sourcePath, destPath)
-      if (!IS_WIN && entry.name === 'ollama') {
+      if (!IS_WIN && (entry.name === 'ollama' || entry.name === 'llama-server')) {
         await chmod(destPath, 0o755)
       }
     }


### PR DESCRIPTION
## Summary

Fixes the managed Ollama install path for the refreshed macOS `v0.30.0` archive, which now requires `llama-server` and sidecar libraries in addition to the `ollama` binary.

## What changed

- Pin managed Ollama downloads to `v0.30.0` instead of the moving `/latest` endpoint.
- Extract the full macOS Ollama archive instead of only the `ollama` file.
- Require packaged macOS managed runtimes to include `llama-server` before treating setup as ready.
- Keep non-macOS Unix managed downloads explicitly unsupported rather than expanding Linux support.
- Add Ask AI backend failure logging so future chat errors include the real exception in `autodocLog`.
- Add onboarding tests covering full macOS extraction and the missing-`llama-server` readiness failure.

## Root cause

AutoDoc extracted only the `ollama` binary from `ollama-darwin.tgz`. Ollama refreshed the `v0.30.0` Darwin artifact on June 1 with a runtime layout that needs `llama-server` and sidecar dylibs. The API server could still start and `/api/tags` could return OK, but model execution failed with `llama-server binary not found`.

## CodeRabbit follow-up

The Linux URL finding was valid against the old non-macOS Unix branch, but Linux is not a supported AutoDoc platform. Rather than add untested Linux support, this PR now makes that path fail clearly as unsupported while preserving the supported macOS/Windows behavior.

## Validation

- Reproduced the failure in a clean sandbox with the old single-file extraction.
- Verified the patched extraction in a clean sandbox using the current `v0.30.0` artifact; `/api/generate` returned HTTP 200.
- `npm run test:main:run -- src/main/ipc/__tests__/chat-ipc.test.ts src/main/services/__tests__/ollama-onboarding-install.test.ts`
- `npm run test:main:run -- src/main/services/__tests__/ollama-onboarding-install.test.ts`
- `npm run typecheck:node`