### PR TITLE
Fix Ask AI conversational routing and ship macOS-only CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ on:
         type: choice
         options:
           - mac
-          - all
+          # - all  # Windows builds disabled — macOS-only for now
       release_tag:
         description: Tag name for release assets (leave blank for non-release runs)
         required: false
@@ -145,8 +145,10 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
+  # Windows builds disabled — macOS-only for now. Re-enable by restoring the `if` below.
+  # if: (github.event_name == 'push' && github.ref_name != 'bugFixes0.1.27') || inputs.release_platform == 'all'
   build-win:
-    if: (github.event_name == 'push' && github.ref_name != 'bugFixes0.1.27') || inputs.release_platform == 'all'
+    if: false
     runs-on: windows-2022
     permissions:
       contents: read
@@ -433,17 +435,12 @@ jobs:
           startsWith(github.ref, 'refs/tags/') ||
           (github.event_name == 'workflow_dispatch' && inputs.release_tag != '')
         ) &&
-        needs.build-mac.result == 'success' &&
-        (
-          startsWith(github.ref, 'refs/tags/') ||
-          inputs.release_platform != 'all' ||
-          needs.build-win.result == 'success'
-        )
+        needs.build-mac.result == 'success'
       }}
     runs-on: ubuntu-latest
     needs:
       - build-mac
-      - build-win
+      # - build-win  # Windows builds disabled — macOS-only for now
     permissions:
       contents: write
 
@@ -467,12 +464,12 @@ jobs:
           name: release-macos-${{ steps.release_meta.outputs.release_tag }}
           path: release-assets/mac
 
-      - name: Download Windows release assets
-        if: (startsWith(github.ref, 'refs/tags/') || inputs.release_platform == 'all') && needs.build-win.result == 'success'
-        uses: actions/download-artifact@v8.0.1
-        with:
-          name: release-windows-${{ steps.release_meta.outputs.release_tag }}
-          path: release-assets/win
+      # - name: Download Windows release assets
+      #   if: (startsWith(github.ref, 'refs/tags/') || inputs.release_platform == 'all') && needs.build-win.result == 'success'
+      #   uses: actions/download-artifact@v8.0.1
+      #   with:
+      #     name: release-windows-${{ steps.release_meta.outputs.release_tag }}
+      #     path: release-assets/win
 
       - name: Publish curated GitHub release assets
         env:
@@ -481,9 +478,9 @@ jobs:
           RELEASE_TAG: ${{ steps.release_meta.outputs.release_tag }}
         run: |
           assets=(release-assets/mac/*)
-          if [ -d release-assets/win ]; then
-            assets+=(release-assets/win/*)
-          fi
+          # if [ -d release-assets/win ]; then
+          #   assets+=(release-assets/win/*)
+          # fi
 
           if gh release view "$RELEASE_TAG" -R "$GH_REPO" >/dev/null 2>&1; then
             gh release upload "$RELEASE_TAG" "${assets[@]}" --clobber -R "$GH_REPO"

--- a/.github/workflows/windows-transcription-assets.yml
+++ b/.github/workflows/windows-transcription-assets.yml
@@ -1,3 +1,4 @@
+# Windows-only asset pipeline — disabled while we ship macOS-only.
 name: Windows Transcription Assets
 
 on:
@@ -16,6 +17,7 @@ on:
 
 jobs:
   build-windows-transcription-assets:
+    if: false # macOS-only for now — re-enable when Windows shipping resumes
     runs-on: windows-2022
     permissions:
       contents: write

--- a/scripts/seed-ask-ai-ad83-fixture.mjs
+++ b/scripts/seed-ask-ai-ad83-fixture.mjs
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+import { mkdir, stat, writeFile } from 'fs/promises'
+import { join, resolve } from 'path'
+
+const args = process.argv.slice(2)
+const recordingsDirArg = readArg('--recordings-dir')
+const force = args.includes('--force')
+
+if (!recordingsDirArg) {
+  console.error(
+    'Usage: node scripts/seed-ask-ai-ad83-fixture.mjs --recordings-dir <path> [--force]'
+  )
+  process.exit(1)
+}
+
+const recordingsDir = resolve(recordingsDirArg)
+
+const fixtures = [
+  {
+    id: 'ad83-001-roadmap-review',
+    title: 'AD83 Fixture - Roadmap Review',
+    startedAt: Date.parse('2026-06-01T14:00:00Z'),
+    topic: 'Roadmap',
+    content: 'First listed fixture notes. The team discussed roadmap sequencing and beta timing.',
+    category: 'information'
+  },
+  {
+    id: 'ad83-002-support-triage',
+    title: 'AD83 Fixture - Support Triage',
+    startedAt: Date.parse('2026-06-01T13:00:00Z'),
+    topic: 'Support',
+    content:
+      'Second listed fixture notes. Casey owns the escalation follow-up and the support macro audit is due Friday.',
+    category: 'actionItems',
+    assignee: 'Casey',
+    deadline: 'Friday'
+  },
+  {
+    id: 'ad83-003-design-sync',
+    title: 'AD83 Fixture - Design Sync',
+    startedAt: Date.parse('2026-06-01T12:00:00Z'),
+    topic: 'Design',
+    content: 'Third listed fixture notes. The group reviewed onboarding copy and empty states.',
+    category: 'discussion'
+  },
+  {
+    id: 'ad83-004-calendar-auth',
+    title: 'AD83 Fixture - Calendar Auth Review',
+    startedAt: Date.parse('2026-06-01T11:00:00Z'),
+    topic: 'Calendar',
+    content:
+      'Fourth listed fixture notes. The team decided to verify Google Calendar scopes before release.',
+    category: 'decisions'
+  }
+]
+
+await mkdir(recordingsDir, { recursive: true })
+
+for (const fixture of fixtures) {
+  const meetingDir = join(recordingsDir, fixture.id)
+  const exists = await stat(meetingDir)
+    .then(() => true)
+    .catch(() => false)
+  if (exists && !force) {
+    console.error(`${meetingDir} already exists. Re-run with --force to overwrite fixture files.`)
+    process.exit(1)
+  }
+
+  await mkdir(meetingDir, { recursive: true })
+  await writeFile(join(meetingDir, 'mic.webm'), '')
+  await writeFile(
+    join(meetingDir, 'metadata.json'),
+    JSON.stringify(
+      {
+        sourceName: fixture.title,
+        startedAt: fixture.startedAt,
+        stoppedAt: fixture.startedAt + 30 * 60_000,
+        durationSeconds: 30 * 60
+      },
+      null,
+      2
+    )
+  )
+  await writeFile(
+    join(meetingDir, 'segments.json'),
+    JSON.stringify(createSegments(fixture), null, 2)
+  )
+  await writeFile(
+    join(meetingDir, 'transcript.json'),
+    JSON.stringify(
+      [
+        {
+          id: `${fixture.id}-transcript-1`,
+          meetingId: fixture.id,
+          speaker: 'speaker-1',
+          text: fixture.content,
+          startMs: 0,
+          endMs: 10_000,
+          confidence: 0.98
+        }
+      ],
+      null,
+      2
+    )
+  )
+}
+
+console.log(`Seeded ${fixtures.length} AD-83 Ask AI fixture recordings in ${recordingsDir}`)
+console.log('Manual repro prompts:')
+console.log('1. list my recordings')
+console.log('2. show notes for the second one')
+console.log('3. so, i have 8 recordings right?')
+console.log('4. awesome, thank you!')
+console.log('5. thanks, can you show action items?')
+
+function readArg(name) {
+  const index = args.indexOf(name)
+  if (index === -1) return null
+  return args[index + 1] ?? null
+}
+
+function createSegments(fixture) {
+  const segments = {
+    decisions: [],
+    actionItems: [],
+    information: [],
+    discussion: [],
+    statusUpdates: []
+  }
+  const note = {
+    id: `${fixture.id}-note-1`,
+    meetingId: fixture.id,
+    category: fixture.category === 'actionItems' ? 'action_item' : 'information',
+    topic: fixture.topic,
+    title: fixture.topic,
+    content: fixture.content,
+    assignee: fixture.assignee ?? null,
+    deadline: fixture.deadline ?? null,
+    sourceStartMs: 0,
+    sourceEndMs: 10_000
+  }
+  segments[fixture.category].push(note)
+  return segments
+}

--- a/src/main/ipc/__tests__/ask-ai-routing.benchmark.test.ts
+++ b/src/main/ipc/__tests__/ask-ai-routing.benchmark.test.ts
@@ -1,0 +1,834 @@
+/**
+ * Ask AI routing benchmark (AD-83).
+ *
+ * This is a re-runnable, deterministic benchmark for the Ask AI *routing* layer
+ * (the deterministic pre-model decisions in `prepareChatContext`: acknowledgements,
+ * count confirmations, ordinal/coreference follow-ups, direct list/count, exact-title,
+ * conversation scoping, and the fast retrieval plan).
+ *
+ * It is intentionally offline and deterministic:
+ *   - the model planner is disabled (AUTODOC_ASK_AI_PLANNER=0)
+ *   - embeddings are disabled (AUTODOC_ASK_AI_EMBEDDINGS=0) so retrieval is lexical
+ *   - `fetch` is stubbed to echo which recordings were placed in model context
+ *
+ * Each case encodes *ground-truth* expected behavior (not a snapshot of current
+ * behavior), so some cases are expected to FAIL on the current implementation.
+ * Those failures are the measured gaps. After the holistic refactor, re-run and
+ * confirm the gaps flip to PASS with zero regressions on previously-passing cases.
+ *
+ * Run:        npm run test:main:run -- src/main/ipc/__tests__/ask-ai-routing.benchmark.test.ts
+ * Save base:  BENCH_SAVE_BASELINE=1 npm run test:main:run -- src/main/ipc/__tests__/ask-ai-routing.benchmark.test.ts
+ */
+import { mkdtemp, mkdir, rm, writeFile } from 'fs/promises'
+import { existsSync, readFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import type { MeetingMetadata, MeetingSegments } from '../../../shared/types'
+
+vi.hoisted(() => {
+  process.env.AUTODOC_ASK_AI_PLANNER = '0'
+  process.env.AUTODOC_ASK_AI_EMBEDDINGS = '0'
+})
+
+const capturedEvents: Array<{ message: string; context: Record<string, unknown> }> = []
+
+vi.mock('electron', () => ({
+  app: { getPath: vi.fn(() => join(tmpdir(), 'autodoc-ask-ai-bench-userdata')) },
+  ipcMain: { handle: vi.fn() }
+}))
+
+vi.mock('../../services/autodoc-log', () => ({
+  logAutodocEvent: vi.fn((entry: { message: string; context?: Record<string, unknown> }) => {
+    capturedEvents.push({ message: entry.message, context: entry.context ?? {} })
+  }),
+  logAutodocFailure: vi.fn()
+}))
+
+import { ipcMain } from 'electron'
+import { registerChatIpc } from '../chat-ipc'
+
+// ---------------------------------------------------------------------------
+// Fixture recordings (ordered most-recent-first when listed): 1..4
+// ---------------------------------------------------------------------------
+interface FixtureRecording {
+  id: string
+  startedAt: number
+  sourceName: string
+  notes: string
+  noteCategory?: keyof MeetingSegments
+  /** distinctive lowercase token found in the title */
+  titleToken: string
+  /** distinctive lowercase token found only in this recording's notes */
+  noteToken: string
+}
+
+const RECORDINGS: FixtureRecording[] = [
+  {
+    id: 'ad83-001-roadmap',
+    startedAt: new Date(2026, 5, 1, 10, 0).getTime(),
+    sourceName: 'AD83 Fixture - Roadmap Review',
+    notes: 'Roadmap sequencing for Q3 was locked. Priya will drive the milestone tracker.',
+    titleToken: 'roadmap',
+    noteToken: 'sequencing'
+  },
+  {
+    id: 'ad83-002-support',
+    startedAt: new Date(2026, 5, 1, 9, 0).getTime(),
+    sourceName: 'AD83 Fixture - Support Triage',
+    notes: 'Casey owns the escalation follow-up for the priority customer queue.',
+    noteCategory: 'actionItems',
+    titleToken: 'support',
+    noteToken: 'escalation'
+  },
+  {
+    id: 'ad83-003-design',
+    startedAt: new Date(2026, 5, 1, 8, 0).getTime(),
+    sourceName: 'AD83 Fixture - Design Sync',
+    notes: 'The team rewrote the onboarding copy and chose the calmer illustration set.',
+    titleToken: 'design',
+    noteToken: 'onboarding'
+  },
+  {
+    id: 'ad83-004-calendar',
+    startedAt: new Date(2026, 5, 1, 7, 0).getTime(),
+    sourceName: 'AD83 Fixture - Calendar Auth Review',
+    notes: 'Google Calendar OAuth scopes need a consent-screen update before launch.',
+    titleToken: 'calendar auth',
+    noteToken: 'consent-screen'
+  }
+]
+
+// ---------------------------------------------------------------------------
+// Outcome + scoring types
+// ---------------------------------------------------------------------------
+interface TurnOutcome {
+  question: string
+  answer: string
+  modelInvoked: boolean
+  route: string
+}
+
+type Check = (o: TurnOutcome) => boolean
+
+interface TurnSpec {
+  question: string
+  /** ground-truth expectation for this turn */
+  check: Check
+  /** human description of the expected behavior */
+  expectation: string
+}
+
+interface Scenario {
+  id: string
+  category: string
+  /** prior assistant/user turns to seed (besides those produced during the run) */
+  seedHistory?: Array<{ role: 'user' | 'assistant'; content: string }>
+  turns: TurnSpec[]
+}
+
+interface CaseResult {
+  scenario: string
+  category: string
+  question: string
+  expectation: string
+  pass: boolean
+  answer: string
+  route: string
+  modelInvoked: boolean
+}
+
+// ---------------------------------------------------------------------------
+// Ground-truth predicate helpers
+// ---------------------------------------------------------------------------
+const lc = (s: string): string => s.toLowerCase()
+
+function isWelcome(o: TurnOutcome): boolean {
+  return /you're welcome|you are welcome/i.test(o.answer)
+}
+
+function notWelcome(o: TurnOutcome): boolean {
+  return !isWelcome(o)
+}
+
+/** Answer references the given recordings and none of the others (by note/title token). */
+function scopedTo(...ids: string[]): Check {
+  const expected = RECORDINGS.filter((r) => ids.includes(r.id))
+  const others = RECORDINGS.filter((r) => !ids.includes(r.id))
+  return (o) => {
+    const text = lc(o.answer)
+    const hitsExpected = expected.every(
+      (r) => text.includes(r.noteToken) || text.includes(r.titleToken)
+    )
+    const leaksOther = others.some((r) => text.includes(r.noteToken))
+    return hitsExpected && !leaksOther
+  }
+}
+
+/** Answer references the given recordings (no exclusion of others). */
+function mentions(...ids: string[]): Check {
+  const expected = RECORDINGS.filter((r) => ids.includes(r.id))
+  return (o) => {
+    const text = lc(o.answer)
+    return expected.every((r) => text.includes(r.noteToken) || text.includes(r.titleToken))
+  }
+}
+
+function countConfirm(
+  actual: number,
+  label: 'local recording' | 'calendar meeting',
+  correct: boolean
+): Check {
+  return (o) => {
+    const text = lc(o.answer)
+    const plural = `${label}${actual === 1 ? '' : 's'}`
+    const mentionsCount = text.includes(`${actual} ${plural}`)
+    const polarityOk = correct ? text.includes('yes, you have') : text.includes('not quite')
+    return mentionsCount && polarityOk
+  }
+}
+
+function deterministic(check: Check): Check {
+  return (o) => !o.modelInvoked && check(o)
+}
+
+// ---------------------------------------------------------------------------
+// The benchmark matrix. Cases marked GAP are expected to fail pre-refactor.
+// ---------------------------------------------------------------------------
+const SCENARIOS: Scenario[] = [
+  // --- A. Direct inventory (baseline) ---
+  {
+    id: 'list-recordings',
+    category: 'direct-inventory',
+    turns: [
+      {
+        question: 'list my recordings',
+        expectation: 'Lists all 4 recordings directly, no model',
+        check: deterministic((o) => /i found 4 recordings total/i.test(o.answer))
+      }
+    ]
+  },
+  {
+    id: 'count-recordings',
+    category: 'direct-inventory',
+    turns: [
+      {
+        question: 'how many recordings do I have?',
+        expectation: 'Answers "You have 4 recordings." directly, no model',
+        check: deterministic((o) => /you have 4 recordings\./i.test(o.answer))
+      }
+    ]
+  },
+
+  // --- B. Acknowledgements ---
+  {
+    id: 'ack-thanks',
+    category: 'acknowledgement',
+    turns: [
+      { question: 'list my recordings', expectation: 'list', check: () => true },
+      {
+        question: 'thanks!',
+        expectation: 'Acknowledged with no retrieval/model',
+        check: deterministic(isWelcome)
+      }
+    ]
+  },
+  {
+    id: 'ack-ok-cool',
+    category: 'acknowledgement',
+    turns: [
+      { question: 'list my recordings', expectation: 'list', check: () => true },
+      {
+        question: 'ok cool',
+        expectation: 'Acknowledged with no retrieval/model',
+        check: deterministic(isWelcome)
+      }
+    ]
+  },
+  {
+    id: 'ack-cheers-GAP',
+    category: 'acknowledgement',
+    turns: [
+      { question: 'list my recordings', expectation: 'list', check: () => true },
+      {
+        question: 'cheers',
+        expectation: 'GAP: "cheers" should be treated as an acknowledgement',
+        check: deterministic(isWelcome)
+      }
+    ]
+  },
+  {
+    id: 'ack-ty-no-worries-GAP',
+    category: 'acknowledgement',
+    turns: [
+      { question: 'list my recordings', expectation: 'list', check: () => true },
+      {
+        question: 'no worries, ty',
+        expectation: 'GAP: casual "no worries, ty" should be an acknowledgement',
+        check: deterministic(isWelcome)
+      }
+    ]
+  },
+  {
+    id: 'ack-much-appreciated-GAP',
+    category: 'acknowledgement',
+    turns: [
+      { question: 'list my recordings', expectation: 'list', check: () => true },
+      {
+        question: 'much appreciated',
+        expectation: 'GAP: "much appreciated" should be an acknowledgement',
+        check: deterministic(isWelcome)
+      }
+    ]
+  },
+  {
+    id: 'ack-not-mixed-request',
+    category: 'acknowledgement',
+    turns: [
+      { question: 'list my recordings', expectation: 'list', check: () => true },
+      {
+        question: 'thanks, can you show action items?',
+        expectation: 'Mixed thanks+request must NOT be swallowed; surfaces action items (Support)',
+        check: (o) => notWelcome(o) && mentions('ad83-002-support')(o)
+      }
+    ]
+  },
+
+  // --- B2. Greetings / small talk (must be instant, no model) ---
+  {
+    id: 'greeting-hey',
+    category: 'smalltalk',
+    turns: [
+      {
+        question: 'hey',
+        expectation: 'Greeting answered instantly with no retrieval/model',
+        check: deterministic((o) => /ask me anything about your meetings/i.test(o.answer))
+      }
+    ]
+  },
+  {
+    id: 'greeting-good-morning',
+    category: 'smalltalk',
+    turns: [
+      {
+        question: 'good morning!',
+        expectation: 'Greeting answered instantly with no retrieval/model',
+        check: deterministic((o) => /ask me anything about your meetings/i.test(o.answer))
+      }
+    ]
+  },
+  {
+    id: 'capability-question',
+    category: 'smalltalk',
+    turns: [
+      {
+        question: 'what can you do?',
+        expectation: 'Capability question answered instantly with no retrieval/model',
+        check: deterministic((o) => /meeting assistant/i.test(o.answer))
+      }
+    ]
+  },
+  {
+    id: 'greeting-with-request-not-smalltalk',
+    category: 'smalltalk',
+    turns: [
+      {
+        question: 'hey, what did we discuss in the design sync?',
+        expectation: 'A greeting glued to a real request routes to retrieval, not small talk',
+        check: (o) =>
+          o.route !== 'smalltalk' && !/ask me anything about your meetings/i.test(o.answer)
+      }
+    ]
+  },
+
+  // --- C. Count confirmations (after listing 4 recordings) ---
+  {
+    id: 'count-confirm-four',
+    category: 'count-confirmation',
+    turns: [
+      { question: 'list my recordings', expectation: 'list', check: () => true },
+      {
+        question: 'so four then?',
+        expectation: 'Confirms 4 recordings from session state, no model',
+        check: deterministic(countConfirm(4, 'local recording', true))
+      }
+    ]
+  },
+  {
+    id: 'count-confirm-five-wrong',
+    category: 'count-confirmation',
+    turns: [
+      { question: 'list my recordings', expectation: 'list', check: () => true },
+      {
+        question: 'so five total?',
+        expectation: 'Corrects to 4 recordings from session state, no model',
+        check: deterministic(countConfirm(4, 'local recording', false))
+      }
+    ]
+  },
+  {
+    id: 'count-confirm-is-that-all-GAP',
+    category: 'count-confirmation',
+    turns: [
+      { question: 'list my recordings', expectation: 'list', check: () => true },
+      {
+        question: 'is that all of them?',
+        expectation: 'GAP: "is that all" should confirm the count from session state',
+        check: deterministic(countConfirm(4, 'local recording', true))
+      }
+    ]
+  },
+  {
+    id: 'count-confirm-only-four-GAP',
+    category: 'count-confirmation',
+    turns: [
+      { question: 'list my recordings', expectation: 'list', check: () => true },
+      {
+        question: 'only 4?',
+        expectation: 'GAP: "only 4?" should confirm the count from session state',
+        check: deterministic(countConfirm(4, 'local recording', true))
+      }
+    ]
+  },
+
+  // --- D. Ordinal / coreference follow-ups (after listing) ---
+  {
+    id: 'ordinal-second',
+    category: 'coreference',
+    turns: [
+      { question: 'list my recordings', expectation: 'list', check: () => true },
+      {
+        question: 'show notes for the second one',
+        expectation: 'Resolves to 2nd listed recording (Support Triage)',
+        check: scopedTo('ad83-002-support')
+      }
+    ]
+  },
+  {
+    id: 'ordinal-third',
+    category: 'coreference',
+    turns: [
+      { question: 'list my recordings', expectation: 'list', check: () => true },
+      {
+        question: 'summarize the third one',
+        expectation: 'Resolves to 3rd listed recording (Design Sync)',
+        check: scopedTo('ad83-003-design')
+      }
+    ]
+  },
+  {
+    id: 'ordinal-last-GAP',
+    category: 'coreference',
+    turns: [
+      { question: 'list my recordings', expectation: 'list', check: () => true },
+      {
+        question: 'show notes for the last one',
+        expectation:
+          'GAP: "the last one" should resolve to the 4th listed recording (Calendar Auth)',
+        check: scopedTo('ad83-004-calendar')
+      }
+    ]
+  },
+  {
+    id: 'title-ref-GAP',
+    category: 'coreference',
+    turns: [
+      { question: 'list my recordings', expectation: 'list', check: () => true },
+      {
+        question: 'tell me about the calendar auth one',
+        expectation: 'GAP: title-style reference should resolve to Calendar Auth Review',
+        check: scopedTo('ad83-004-calendar')
+      }
+    ]
+  },
+
+  // --- E. Quantity-as-ordinal false positives (HIGH severity) ---
+  {
+    id: 'quantity-top-3-from-support-GAP',
+    category: 'quantity-vs-ordinal',
+    turns: [
+      { question: 'list my recordings', expectation: 'list', check: () => true },
+      {
+        question: 'what are the top 3 action items from the support meeting?',
+        expectation:
+          'GAP: "3" is a quantity, not an ordinal; must scope to Support, not the 3rd recording',
+        check: scopedTo('ad83-002-support')
+      }
+    ]
+  },
+  {
+    id: 'quantity-2-takeaways-roadmap-GAP',
+    category: 'quantity-vs-ordinal',
+    turns: [
+      { question: 'list my recordings', expectation: 'list', check: () => true },
+      {
+        question: 'give me 2 takeaways from the roadmap review',
+        expectation:
+          'GAP: "2" is a quantity, not an ordinal; must scope to Roadmap, not the 2nd recording',
+        check: scopedTo('ad83-001-roadmap')
+      }
+    ]
+  },
+
+  // --- F. Affirmation must not be swallowed as thanks (HIGH severity) ---
+  {
+    id: 'yes-after-clarification-GAP',
+    category: 'affirmation',
+    seedHistory: [
+      { role: 'user', content: 'pull up the roadmap meeting' },
+      {
+        role: 'assistant',
+        content:
+          'I found a few possible matching meetings. Which one should I use? 1. Roadmap Review 2. Design Sync'
+      }
+    ],
+    turns: [
+      {
+        question: 'yes the first one',
+        expectation:
+          'GAP: an affirmation answering a clarification must NOT return "You\'re welcome."',
+        check: notWelcome
+      }
+    ]
+  },
+
+  // --- G. New search after a prior selection must not pin (regression guard) ---
+  {
+    id: 'new-search-not-pinned',
+    category: 'scope-isolation',
+    turns: [
+      {
+        question: 'summarize the design sync',
+        expectation: 'Scopes to Design Sync',
+        check: scopedTo('ad83-003-design')
+      },
+      {
+        question: 'who owns the escalation follow-up?',
+        expectation: 'New question must retrieve Support Triage, not stay pinned to Design Sync',
+        check: scopedTo('ad83-002-support')
+      }
+    ]
+  }
+]
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+function deriveRoute(events: Array<{ message: string; context: Record<string, unknown> }>): string {
+  const routed = events.find((e) => e.message === 'chat routed without retrieval')
+  if (routed) return String(routed.context.route ?? 'routed')
+
+  const retrieval = events.find((e) => e.message === 'chat retrieval completed')
+  if (!retrieval) return 'unknown'
+  const c = retrieval.context
+  if (c.calendarSkippedByDirectIntent) return `direct:${c.matchMode ?? '?'}`
+  if (c.calendarSkippedByLocalExactMatch) return 'exact-title'
+  if (c.conversationScopedFollowUp && c.scopedToFocusedRecordings) return 'scoped:focused'
+  if (c.conversationScopedFollowUp && c.scopedToPreviousCalendarList) return 'scoped:calendar-list'
+  if (c.conversationScopedFollowUp) return 'scoped:followup'
+  if (c.calendarSkippedByLocalRecordingEvidence) return 'local-recording'
+  if (c.plannerSource) return `plan:${c.plannerSource}`
+  return 'calendar-fallback'
+}
+
+function jsonResponse(value: unknown): Response {
+  return { ok: true, json: async () => value } as Response
+}
+
+function streamResponse(content: string): Response {
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(`${JSON.stringify({ message: { content } })}\n`))
+      controller.close()
+    }
+  })
+  return { ok: true, body: stream } as Response
+}
+
+describe('Ask AI routing benchmark (AD-83)', () => {
+  let baseDir: string
+  let streamHandler: (...args: unknown[]) => Promise<void>
+  let waitUntilReady: ReturnType<typeof vi.fn>
+  const results: CaseResult[] = []
+
+  beforeAll(async () => {
+    baseDir = await mkdtemp(join(tmpdir(), 'autodoc-ask-ai-bench-'))
+    for (const rec of RECORDINGS) {
+      await createRecording(baseDir, rec)
+    }
+
+    waitUntilReady = vi.fn().mockResolvedValue(undefined)
+
+    // Stub fetch: echo which recordings were placed into model context.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string, init?: RequestInit) => {
+        const u = String(url)
+        if (u.endsWith('/api/tags')) return jsonResponse({ models: [] })
+        if (u.endsWith('/api/embed')) return jsonResponse({ embeddings: [] })
+        if (u.endsWith('/api/chat')) {
+          const body = JSON.parse(String(init?.body)) as {
+            format?: string
+            messages: Array<{ content: string }>
+          }
+          if (body.format === 'json') return jsonResponse({ message: { content: '{}' } })
+          const text = lc(JSON.stringify(body.messages))
+          const found = [
+            ...new Set(
+              RECORDINGS.flatMap((r) => [r.titleToken, r.noteToken].filter((t) => text.includes(t)))
+            )
+          ]
+          return streamResponse(`MODEL_ANSWER scope=[${found.join(', ')}]`)
+        }
+        return jsonResponse({})
+      })
+    )
+
+    registerChatIpc(
+      baseDir,
+      { waitUntilReady, isServerRunning: vi.fn(), getBaseUrl: () => 'http://localhost:11434' },
+      { getModel: () => 'fake-model' } as never,
+      {
+        fetchAllRecentEvents: vi.fn().mockResolvedValue([]),
+        fetchAllUpcomingEvents: vi.fn().mockResolvedValue([])
+      } as never
+    )
+
+    streamHandler = vi
+      .mocked(ipcMain.handle)
+      .mock.calls.find(([channel]) => channel === 'chat:send-stream')?.[1] as never
+  })
+
+  afterAll(async () => {
+    await writeScorecard(results)
+    await rm(baseDir, { recursive: true, force: true })
+  })
+
+  it('runs the routing matrix and produces a scorecard', async () => {
+    let senderId = 1000
+    for (const scenario of SCENARIOS) {
+      senderId += 1
+      const sender = { id: senderId, send: vi.fn() }
+      const history: Array<{ role: 'user' | 'assistant'; content: string }> = [
+        ...(scenario.seedHistory ?? [])
+      ]
+
+      for (let i = 0; i < scenario.turns.length; i++) {
+        const turn = scenario.turns[i]
+        const requestId = `${scenario.id}-${i}`
+        const eventsBefore = capturedEvents.length
+        const waitBefore = waitUntilReady.mock.calls.length
+
+        await streamHandler({ sender } as never, requestId, turn.question, history.slice(-8))
+
+        const answer = getDoneContent(sender.send, requestId)
+        const turnEvents = capturedEvents.slice(eventsBefore)
+        const outcome: TurnOutcome = {
+          question: turn.question,
+          answer,
+          modelInvoked: waitUntilReady.mock.calls.length > waitBefore,
+          route: deriveRoute(turnEvents)
+        }
+
+        history.push({ role: 'user', content: turn.question })
+        history.push({ role: 'assistant', content: answer })
+
+        // Only score "real" assertion turns; seed/list turns use `() => true`.
+        const pass = turn.check(outcome)
+        results.push({
+          scenario: scenario.id,
+          category: scenario.category,
+          question: turn.question,
+          expectation: turn.expectation,
+          pass,
+          answer,
+          route: outcome.route,
+          modelInvoked: outcome.modelInvoked
+        })
+      }
+    }
+
+    // The benchmark is a measurement, not a gate: it always "passes" as long as
+    // every case produced a result. The scorecard captures the real signal.
+    const expectedCases = SCENARIOS.reduce((n, s) => n + s.turns.length, 0)
+    expect(results.length).toBe(expectedCases)
+    printSummary(results)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Reporting
+// ---------------------------------------------------------------------------
+const REPORT_DIR = join(process.cwd(), 'artifacts', 'ask-ai-benchmark')
+const LATEST_PATH = join(REPORT_DIR, 'latest.json')
+const BASELINE_PATH = join(REPORT_DIR, 'baseline.json')
+const MARKDOWN_PATH = join(REPORT_DIR, 'scorecard.md')
+
+interface Scorecard {
+  generatedAt: string
+  total: number
+  passed: number
+  failed: number
+  passRate: number
+  byCategory: Record<string, { passed: number; total: number }>
+  cases: CaseResult[]
+}
+
+function buildScorecard(results: CaseResult[]): Scorecard {
+  const scored = results.filter((r) => r.expectation !== 'list')
+  const passed = scored.filter((r) => r.pass).length
+  const byCategory: Record<string, { passed: number; total: number }> = {}
+  for (const r of scored) {
+    const bucket = (byCategory[r.category] ??= { passed: 0, total: 0 })
+    bucket.total += 1
+    if (r.pass) bucket.passed += 1
+  }
+  return {
+    generatedAt: new Date().toISOString(),
+    total: scored.length,
+    passed,
+    failed: scored.length - passed,
+    passRate: scored.length === 0 ? 0 : Math.round((passed / scored.length) * 1000) / 10,
+    byCategory,
+    cases: scored
+  }
+}
+
+async function writeScorecard(results: CaseResult[]): Promise<void> {
+  const scorecard = buildScorecard(results)
+  await mkdir(REPORT_DIR, { recursive: true })
+  await writeFile(LATEST_PATH, `${JSON.stringify(scorecard, null, 2)}\n`)
+  if (process.env.BENCH_SAVE_BASELINE === '1') {
+    await writeFile(BASELINE_PATH, `${JSON.stringify(scorecard, null, 2)}\n`)
+  }
+  await writeFile(MARKDOWN_PATH, renderMarkdown(scorecard))
+}
+
+function renderMarkdown(s: Scorecard): string {
+  const lines: string[] = []
+  lines.push('# Ask AI routing benchmark scorecard')
+  lines.push('')
+  lines.push(`- Generated: ${s.generatedAt}`)
+  lines.push(`- Pass rate: **${s.passRate}%** (${s.passed}/${s.total})`)
+  lines.push('')
+  lines.push('## By category')
+  lines.push('')
+  lines.push('| Category | Pass | Total |')
+  lines.push('| --- | --- | --- |')
+  for (const [cat, v] of Object.entries(s.byCategory)) {
+    lines.push(`| ${cat} | ${v.passed} | ${v.total} |`)
+  }
+  lines.push('')
+  lines.push('## Cases')
+  lines.push('')
+  lines.push('| ✓ | Scenario | Question | Expectation | Route | Model? | Answer |')
+  lines.push('| --- | --- | --- | --- | --- | --- | --- |')
+  for (const c of s.cases) {
+    const ans = c.answer.replace(/\n+/g, ' ').slice(0, 80).replace(/\|/g, '\\|')
+    lines.push(
+      `| ${c.pass ? '✅' : '❌'} | ${c.scenario} | ${c.question.replace(/\|/g, '\\|')} | ${c.expectation.replace(/\|/g, '\\|')} | ${c.route} | ${c.modelInvoked ? 'yes' : 'no'} | ${ans} |`
+    )
+  }
+  lines.push('')
+  return lines.join('\n')
+}
+
+function printSummary(results: CaseResult[]): void {
+  const s = buildScorecard(results)
+  const lines = [
+    '',
+    '════════ Ask AI routing benchmark ════════',
+    `Pass rate: ${s.passRate}%  (${s.passed}/${s.total})`,
+    ''
+  ]
+  for (const c of s.cases) {
+    if (!c.pass)
+      lines.push(
+        `  ❌ [${c.category}] ${c.scenario}: "${c.question}" → route=${c.route} model=${c.modelInvoked}`
+      )
+  }
+
+  let baselineNote = ''
+  if (existsSync(BASELINE_PATH)) {
+    try {
+      const baseline = JSON.parse(readFileSync(BASELINE_PATH, 'utf-8')) as Scorecard
+      const delta = s.passed - baseline.passed
+      const regressed = baseline.cases
+        .filter((b) => b.pass)
+        .filter((b) => {
+          const cur = s.cases.find((c) => c.scenario === b.scenario && c.question === b.question)
+          return cur && !cur.pass
+        })
+        .map((b) => b.scenario)
+      baselineNote = `\nvs baseline: ${delta >= 0 ? '+' : ''}${delta} (${baseline.passed} → ${s.passed})`
+      if (regressed.length > 0) baselineNote += `\n  ⚠️ REGRESSIONS: ${regressed.join(', ')}`
+    } catch {
+      // ignore
+    }
+  }
+  lines.push(baselineNote)
+  lines.push('═══════════════════════════════════════════')
+
+  console.log(lines.join('\n'))
+}
+
+// ---------------------------------------------------------------------------
+// Fixture + helpers (mirrors chat-ipc.test.ts)
+// ---------------------------------------------------------------------------
+async function createRecording(baseDir: string, rec: FixtureRecording): Promise<void> {
+  const meetingDir = join(baseDir, rec.id)
+  await mkdir(meetingDir, { recursive: true })
+  await writeFile(join(meetingDir, 'mic.webm'), '')
+
+  const metadata: MeetingMetadata = {
+    sourceName: rec.sourceName,
+    startedAt: rec.startedAt,
+    stoppedAt: rec.startedAt + 30 * 60_000,
+    durationSeconds: 30 * 60
+  }
+  await writeFile(join(meetingDir, 'metadata.json'), JSON.stringify(metadata))
+  await writeFile(
+    join(meetingDir, 'segments.json'),
+    JSON.stringify(createSegments(rec.notes, rec.noteCategory))
+  )
+}
+
+function createSegments(
+  content: string,
+  noteCategory: keyof MeetingSegments = 'information'
+): MeetingSegments {
+  const segments: MeetingSegments = {
+    decisions: [],
+    actionItems: [],
+    information: [],
+    discussion: [],
+    statusUpdates: []
+  }
+  segments[noteCategory] = [
+    {
+      id: 'note-1',
+      meetingId: 'fixture',
+      category: noteCategory === 'actionItems' ? 'action_item' : 'information',
+      topic: 'General',
+      title: 'Fixture note',
+      content,
+      assignee: noteCategory === 'actionItems' ? 'Casey' : null,
+      deadline: noteCategory === 'actionItems' ? 'Friday' : null,
+      sourceStartMs: 0,
+      sourceEndMs: 10_000
+    }
+  ]
+  return segments
+}
+
+function getDoneContent(send: ReturnType<typeof vi.fn>, requestId: string): string {
+  const doneCall = send.mock.calls.find(
+    ([channel, payload]) => channel === 'chat:done' && payload?.requestId === requestId
+  )
+  if (doneCall) return doneCall[1].content
+  const errorCall = send.mock.calls.find(
+    ([channel, payload]) => channel === 'chat:error' && payload?.requestId === requestId
+  )
+  if (errorCall) return `__ERROR__: ${errorCall[1].error}`
+  return '__NO_RESPONSE__'
+}

--- a/src/main/ipc/__tests__/chat-ipc.test.ts
+++ b/src/main/ipc/__tests__/chat-ipc.test.ts
@@ -312,6 +312,233 @@ describe('chat meeting retrieval helpers', () => {
     })
   })
 
+  it('routes conversational acknowledgements without retrieval or Ollama', async () => {
+    const waitUntilReady = vi.fn()
+    const fetchAllRecentEvents = vi.fn()
+    const fetchAllUpcomingEvents = vi.fn()
+
+    registerChatIpc(
+      '/tmp/autodoc-chat-empty',
+      {
+        waitUntilReady,
+        isServerRunning: vi.fn(),
+        getBaseUrl: () => 'http://localhost:11434'
+      },
+      { getModel: () => 'fake-model' } as never,
+      {
+        fetchAllRecentEvents,
+        fetchAllUpcomingEvents
+      } as never
+    )
+
+    const streamHandler = vi
+      .mocked(ipcMain.handle)
+      .mock.calls.find(([channel]) => channel === 'chat:send-stream')?.[1]
+    const sender = { id: 201, send: vi.fn() }
+
+    await streamHandler?.({ sender } as never, 'req-thanks', 'awesome, thank you!', [
+      { role: 'assistant', content: 'I found 4 recordings.' }
+    ])
+
+    expect(sender.send).toHaveBeenCalledWith('chat:done', {
+      requestId: 'req-thanks',
+      content: "You're welcome."
+    })
+    expect(waitUntilReady).not.toHaveBeenCalled()
+    expect(fetchAllRecentEvents).not.toHaveBeenCalled()
+    expect(fetchAllUpcomingEvents).not.toHaveBeenCalled()
+  })
+
+  it('answers count confirmations from prior calendar scope without invoking the model', async () => {
+    const waitUntilReady = vi.fn()
+    const now = new Date()
+    now.setHours(9, 0, 0, 0)
+    const events = [0, 1].map((offset) => ({
+      id: `google_event_${offset}`,
+      externalId: `event_${offset}`,
+      accountId: 'google',
+      provider: 'google',
+      recurringEventId: null,
+      title: offset === 0 ? 'Design Sync' : 'Support Triage',
+      startTime: now.getTime() + offset * 60 * 60_000,
+      endTime: now.getTime() + offset * 60 * 60_000 + 30 * 60_000,
+      attendees: [],
+      meetingUrl: null,
+      autoRecord: 'off',
+      syncedAt: now.getTime()
+    }))
+
+    registerChatIpc(
+      '/tmp/autodoc-chat-empty',
+      {
+        waitUntilReady,
+        isServerRunning: vi.fn(),
+        getBaseUrl: () => 'http://localhost:11434'
+      },
+      { getModel: () => 'fake-model' } as never,
+      {
+        fetchAllRecentEvents: vi.fn().mockResolvedValue(events),
+        fetchAllUpcomingEvents: vi.fn().mockResolvedValue([])
+      } as never
+    )
+
+    const streamHandler = vi
+      .mocked(ipcMain.handle)
+      .mock.calls.find(([channel]) => channel === 'chat:send-stream')?.[1]
+    const sender = { id: 202, send: vi.fn() }
+
+    await streamHandler?.({ sender } as never, 'req-calendar', 'what meetings did I have today')
+    await streamHandler?.({ sender } as never, 'req-confirm', 'so, i have 8 meetings right?')
+
+    expect(sender.send).toHaveBeenCalledWith('chat:done', {
+      requestId: 'req-confirm',
+      content: 'Not quite - you have 2 calendar meetings in that list.'
+    })
+    expect(waitUntilReady).not.toHaveBeenCalled()
+  })
+
+  it('resolves ordinal follow-ups against the previously listed recordings', async () => {
+    const baseDir = await createTempRecordingsDir()
+    await createRecording(baseDir, 'newer-roadmap', {
+      startedAt: new Date(2026, 5, 1, 10, 0).getTime(),
+      sourceName: 'Roadmap Review',
+      notes: 'First listed meeting notes.'
+    })
+    await createRecording(baseDir, 'older-support', {
+      startedAt: new Date(2026, 5, 1, 9, 0).getTime(),
+      sourceName: 'Support Triage',
+      notes: 'Second listed meeting notes about escalation follow-up.'
+    })
+
+    registerChatIpc(
+      baseDir,
+      {
+        waitUntilReady: vi.fn(),
+        isServerRunning: vi.fn(),
+        getBaseUrl: () => 'http://localhost:11434'
+      },
+      { getModel: () => 'fake-model' } as never,
+      {
+        fetchAllRecentEvents: vi.fn().mockResolvedValue([]),
+        fetchAllUpcomingEvents: vi.fn().mockResolvedValue([])
+      } as never
+    )
+
+    const streamHandler = vi
+      .mocked(ipcMain.handle)
+      .mock.calls.find(([channel]) => channel === 'chat:send-stream')?.[1]
+    const sender = { id: 203, send: vi.fn() }
+
+    await streamHandler?.({ sender } as never, 'req-list', 'list my recordings')
+    await streamHandler?.({ sender } as never, 'req-second', 'show notes for the second one')
+
+    expect(sender.send).toHaveBeenCalledWith('chat:done', {
+      requestId: 'req-second',
+      content: expect.stringContaining('Second listed meeting notes')
+    })
+    expect(sender.send).not.toHaveBeenCalledWith('chat:done', {
+      requestId: 'req-second',
+      content: expect.stringContaining('First listed meeting notes')
+    })
+  })
+
+  it('covers adjacent Ask AI prompt variants around thanks, counts, ordinals, and requests', async () => {
+    const baseDir = await createTempRecordingsDir()
+    await createRecording(baseDir, 'ad83-001-roadmap', {
+      startedAt: new Date(2026, 5, 1, 10, 0).getTime(),
+      sourceName: 'AD83 Fixture - Roadmap Review',
+      notes: 'First listed fixture notes about roadmap sequencing.'
+    })
+    await createRecording(baseDir, 'ad83-002-support', {
+      startedAt: new Date(2026, 5, 1, 9, 0).getTime(),
+      sourceName: 'AD83 Fixture - Support Triage',
+      notes: 'Second listed fixture notes. Casey owns the escalation follow-up.',
+      noteCategory: 'actionItems'
+    })
+    await createRecording(baseDir, 'ad83-003-design', {
+      startedAt: new Date(2026, 5, 1, 8, 0).getTime(),
+      sourceName: 'AD83 Fixture - Design Sync',
+      notes: 'Third listed fixture notes about onboarding copy.'
+    })
+    await createRecording(baseDir, 'ad83-004-calendar', {
+      startedAt: new Date(2026, 5, 1, 7, 0).getTime(),
+      sourceName: 'AD83 Fixture - Calendar Auth Review',
+      notes: 'Fourth listed fixture notes about Google Calendar scopes.'
+    })
+
+    const waitUntilReady = vi.fn()
+    registerChatIpc(
+      baseDir,
+      {
+        waitUntilReady,
+        isServerRunning: vi.fn(),
+        getBaseUrl: () => 'http://localhost:11434'
+      },
+      { getModel: () => 'fake-model' } as never,
+      {
+        fetchAllRecentEvents: vi.fn().mockResolvedValue([]),
+        fetchAllUpcomingEvents: vi.fn().mockResolvedValue([])
+      } as never
+    )
+
+    const streamHandler = vi
+      .mocked(ipcMain.handle)
+      .mock.calls.find(([channel]) => channel === 'chat:send-stream')?.[1]
+    const sender = { id: 204, send: vi.fn() }
+    const ask = async (
+      requestId: string,
+      question: string,
+      history: Array<{ role: 'user' | 'assistant'; content: string }> = []
+    ): Promise<string> => {
+      await streamHandler?.({ sender } as never, requestId, question, history)
+      return getDoneContent(sender.send, requestId)
+    }
+
+    const listAnswer = await ask('req-list', 'list my recordings')
+    expect(listAnswer).toContain('I found 4 recordings total')
+
+    await expect(
+      ask('req-2nd', 'show notes for the 2nd one', [
+        { role: 'user', content: 'list my recordings' },
+        { role: 'assistant', content: listAnswer }
+      ])
+    ).resolves.toContain('Second listed fixture notes')
+
+    await expect(
+      ask('req-right-now', 'show notes for the 2nd recording right now')
+    ).resolves.toContain('Second listed fixture notes')
+
+    await expect(ask('req-four-then', 'so four then?')).resolves.toBe(
+      'Yes, you have 4 local recordings in that list.'
+    )
+    await expect(ask('req-five-total', 'so five total?')).resolves.toBe(
+      'Not quite - you have 4 local recordings in that list.'
+    )
+
+    for (const [requestId, prompt] of [
+      ['req-ok-cool', 'ok cool'],
+      ['req-sounds-good', 'sounds good'],
+      ['req-got-it', 'got it'],
+      ['req-thx', 'thx']
+    ] as const) {
+      await expect(
+        ask(requestId, prompt, [
+          { role: 'user', content: 'list my recordings' },
+          { role: 'assistant', content: listAnswer }
+        ])
+      ).resolves.toBe("You're welcome.")
+    }
+
+    await expect(
+      ask('req-thanks-request', 'thanks, can you show action items?')
+    ).resolves.toContain('Casey owns the escalation follow-up')
+    await expect(ask('req-cool-request', 'cool, summarize the third one')).resolves.toContain(
+      'Third listed fixture notes'
+    )
+
+    expect(waitUntilReady).not.toHaveBeenCalled()
+  })
+
   it('does not pin a new short content question to the previous exact-title recording', async () => {
     const baseDir = await createTempRecordingsDir()
     await createRecording(baseDir, 'slack-qa', {
@@ -433,4 +660,12 @@ function createSegments(content: string, noteCategory: keyof MeetingSegments = '
     }
   ]
   return segments
+}
+
+function getDoneContent(send: ReturnType<typeof vi.fn>, requestId: string): string {
+  const doneCall = send.mock.calls.find(
+    ([channel, payload]) => channel === 'chat:done' && payload?.requestId === requestId
+  )
+  if (!doneCall) throw new Error(`Missing chat:done for ${requestId}`)
+  return doneCall[1].content
 }

--- a/src/main/ipc/__tests__/chat-ipc.test.ts
+++ b/src/main/ipc/__tests__/chat-ipc.test.ts
@@ -539,6 +539,63 @@ describe('chat meeting retrieval helpers', () => {
     expect(waitUntilReady).not.toHaveBeenCalled()
   })
 
+  it('aborts an in-flight streaming request and emits chat:canceled instead of chat:error', async () => {
+    const baseDir = await createTempRecordingsDir()
+
+    const fetchMock = vi.fn((_url: string, init?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        const signal = init?.signal
+        const fail = (): void => reject(Object.assign(new Error('aborted'), { name: 'AbortError' }))
+        if (signal?.aborted) {
+          fail()
+          return
+        }
+        signal?.addEventListener('abort', fail)
+      })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    registerChatIpc(
+      baseDir,
+      {
+        waitUntilReady: vi.fn(),
+        isServerRunning: vi.fn(),
+        getBaseUrl: () => 'http://localhost:11434'
+      },
+      { getModel: () => 'fake-model' } as never,
+      {
+        fetchAllRecentEvents: vi.fn().mockResolvedValue([]),
+        fetchAllUpcomingEvents: vi.fn().mockResolvedValue([])
+      } as never
+    )
+
+    const streamHandler = vi
+      .mocked(ipcMain.handle)
+      .mock.calls.find(([channel]) => channel === 'chat:send-stream')?.[1]
+    const cancelHandler = vi
+      .mocked(ipcMain.handle)
+      .mock.calls.find(([channel]) => channel === 'chat:cancel')?.[1]
+    const sender = { id: 301, send: vi.fn() }
+
+    const streamPromise = streamHandler?.(
+      { sender } as never,
+      'req-cancel',
+      'what should I focus on?'
+    )
+
+    for (let i = 0; i < 100 && fetchMock.mock.calls.length === 0; i += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    }
+    expect(fetchMock).toHaveBeenCalled()
+
+    await cancelHandler?.({} as never, 'req-cancel')
+    await streamPromise
+
+    expect(sender.send).toHaveBeenCalledWith('chat:canceled', { requestId: 'req-cancel' })
+    expect(sender.send).not.toHaveBeenCalledWith('chat:error', expect.anything())
+    expect(sender.send).not.toHaveBeenCalledWith('chat:done', expect.anything())
+  })
+
   it('does not pin a new short content question to the previous exact-title recording', async () => {
     const baseDir = await createTempRecordingsDir()
     await createRecording(baseDir, 'slack-qa', {
@@ -637,7 +694,10 @@ async function createRecording(
   )
 }
 
-function createSegments(content: string, noteCategory: keyof MeetingSegments = 'information') {
+function createSegments(
+  content: string,
+  noteCategory: keyof MeetingSegments = 'information'
+): MeetingSegments {
   const segments: MeetingSegments = {
     decisions: [],
     actionItems: [],

--- a/src/main/ipc/chat-ipc.ts
+++ b/src/main/ipc/chat-ipc.ts
@@ -172,10 +172,40 @@ export function registerChatIpc(
     context: string
     clarificationOptions?: ChatClarificationOption[]
   }> => {
+    const acknowledgementAnswer = buildAcknowledgementAnswer(question, history)
+    if (acknowledgementAnswer) {
+      logAutodocEvent({
+        area: 'chat',
+        message: 'chat routed without retrieval',
+        context: {
+          route: 'conversational-acknowledgement',
+          questionLength: question.length
+        }
+      })
+      return { directAnswer: acknowledgementAnswer, context: '' }
+    }
+
+    const countConfirmationAnswer = buildCountConfirmationAnswer(question, session)
+    if (countConfirmationAnswer) {
+      logAutodocEvent({
+        area: 'chat',
+        message: 'chat routed without retrieval',
+        context: {
+          route: 'count-confirmation',
+          questionLength: question.length,
+          previousCalendarCount: session.lastCalendarEvents.length,
+          previousRecordingCount: session.lastRecordingIds.length
+        }
+      })
+      return { directAnswer: countConfirmationAnswer, context: '' }
+    }
+
     const intent = detectChatIntent(question)
     if (intent === 'count' || intent === 'list') {
       clearConversationScope(session)
       const meetingContext = await recordingIndex.buildContext(question, [])
+      session.lastRecordingIds = meetingContext.diagnostics.matchedMeetingIds
+      session.focusedRecordingIds = []
       updateClarificationState(session, meetingContext)
       logAutodocEvent({
         area: 'chat',
@@ -307,6 +337,40 @@ export function registerChatIpc(
     session: ChatConversationState
   ): Promise<PreparedChatContext | null> => {
     if (shouldStartNewConversationScope(question)) return null
+
+    const scopedIds = resolveScopedRecordingIds(question, session)
+    if (scopedIds.length > 0 && shouldUseConversationScope(question)) {
+      const meetingContext = await recordingIndex.buildContextForMeetingIds(
+        buildScopedQuestion(question, session),
+        scopedIds,
+        session.lastCalendarEvents
+      )
+      session.lastRecordingIds = mergeScopedRecordingIds(
+        session.lastRecordingIds,
+        meetingContext.diagnostics.selectedMeetingIds
+      )
+      session.focusedRecordingIds = meetingContext.diagnostics.selectedMeetingIds
+      updateClarificationState(session, meetingContext)
+      logAutodocEvent({
+        area: 'chat',
+        message: 'chat retrieval completed',
+        context: {
+          ...meetingContext.diagnostics,
+          conversationScopedFollowUp: true,
+          scopedToFocusedRecordings: true,
+          calendarElapsedMs: 0,
+          calendarSkippedByBackoff: false,
+          calendarRecentCount: session.lastCalendarEvents.length,
+          calendarUpcomingCount: 0
+        }
+      })
+      return {
+        directAnswer: meetingContext.directAnswer,
+        context: meetingContext.context,
+        clarificationOptions: meetingContext.clarificationOptions
+      }
+    }
+
     if (hasFreshSearchTerms(normalizeRecordingSearchText(question))) return null
 
     if (asksForNotesInPreviousSet(question) && session.lastCalendarEvents.length > 0) {
@@ -323,36 +387,6 @@ export function registerChatIpc(
         context: {
           ...meetingContext.diagnostics,
           conversationScopedFollowUp: true,
-          calendarElapsedMs: 0,
-          calendarSkippedByBackoff: false,
-          calendarRecentCount: session.lastCalendarEvents.length,
-          calendarUpcomingCount: 0
-        }
-      })
-      return {
-        directAnswer: meetingContext.directAnswer,
-        context: meetingContext.context,
-        clarificationOptions: meetingContext.clarificationOptions
-      }
-    }
-
-    const scopedIds = resolveScopedRecordingIds(question, session)
-    if (scopedIds.length > 0 && shouldUseConversationScope(question)) {
-      const meetingContext = await recordingIndex.buildContextForMeetingIds(
-        buildScopedQuestion(question, session),
-        scopedIds,
-        session.lastCalendarEvents
-      )
-      session.lastRecordingIds = meetingContext.diagnostics.selectedMeetingIds
-      session.focusedRecordingIds = meetingContext.diagnostics.selectedMeetingIds
-      updateClarificationState(session, meetingContext)
-      logAutodocEvent({
-        area: 'chat',
-        message: 'chat retrieval completed',
-        context: {
-          ...meetingContext.diagnostics,
-          conversationScopedFollowUp: true,
-          scopedToFocusedRecordings: true,
           calendarElapsedMs: 0,
           calendarSkippedByBackoff: false,
           calendarRecentCount: session.lastCalendarEvents.length,
@@ -719,6 +753,173 @@ function updateClarificationState(
   session.lastClarificationOptions = result.clarificationOptions ?? []
 }
 
+function buildAcknowledgementAnswer(
+  question: string,
+  history: ChatHistoryMessage[]
+): string | null {
+  const normalized = normalizeRecordingSearchText(question)
+  if (!normalized) return null
+  if (hasRequestCue(normalized) || hasMeetingDataCue(normalized)) return null
+
+  const tokens = normalized.split(' ').filter(Boolean)
+  if (tokens.length === 0 || tokens.length > 8) return null
+
+  const nonAckTokens = tokens.filter((token) => !ACKNOWLEDGEMENT_TERMS.has(token))
+  if (nonAckTokens.length > 0) return null
+
+  const hasPriorAssistantTurn = history.some((message) => message.role === 'assistant')
+  if (!hasPriorAssistantTurn && !tokens.some((token) => token === 'thanks' || token === 'thank')) {
+    return null
+  }
+
+  return "You're welcome."
+}
+
+function buildCountConfirmationAnswer(
+  question: string,
+  session: ChatConversationState
+): string | null {
+  const normalized = normalizeRecordingSearchText(question)
+  if (!isCountConfirmationQuestion(normalized, session)) return null
+
+  const referencedCount = extractReferencedCount(normalized)
+  if (/\brecordings?\b/.test(normalized) && session.lastRecordingIds.length > 0) {
+    return formatCountConfirmationAnswer({
+      label: 'local recording',
+      actualCount: session.lastRecordingIds.length,
+      referencedCount
+    })
+  }
+
+  if (/\b(meetings?|calls?|standups?|syncs?)\b/.test(normalized)) {
+    if (session.lastCalendarEvents.length > 0) {
+      return formatCountConfirmationAnswer({
+        label: 'calendar meeting',
+        actualCount: session.lastCalendarEvents.length,
+        referencedCount
+      })
+    }
+
+    if (session.lastRecordingIds.length > 0) {
+      return formatCountConfirmationAnswer({
+        label: 'local recording',
+        actualCount: session.lastRecordingIds.length,
+        referencedCount
+      })
+    }
+  }
+
+  if (!/\b(meetings?|recordings?|calls?|standups?|syncs?)\b/.test(normalized)) {
+    if (session.lastCalendarEvents.length > 0 && session.lastRecordingIds.length === 0) {
+      return formatCountConfirmationAnswer({
+        label: 'calendar meeting',
+        actualCount: session.lastCalendarEvents.length,
+        referencedCount
+      })
+    }
+
+    if (session.lastRecordingIds.length > 0 && session.lastCalendarEvents.length === 0) {
+      return formatCountConfirmationAnswer({
+        label: 'local recording',
+        actualCount: session.lastRecordingIds.length,
+        referencedCount
+      })
+    }
+  }
+
+  return null
+}
+
+const ACKNOWLEDGEMENT_TERMS = new Set([
+  'amazing',
+  'appreciate',
+  'appreciated',
+  'awesome',
+  'cool',
+  'good',
+  'got',
+  'great',
+  'it',
+  'nice',
+  'ok',
+  'okay',
+  'perfect',
+  'sounds',
+  'sweet',
+  'thank',
+  'thanks',
+  'thx',
+  'yep',
+  'yes',
+  'you'
+])
+
+function hasRequestCue(normalizedQuestion: string): boolean {
+  return /\b(can|could|would|please|show|list|summarize|summary|recap|find|search|tell|explain|what|which|who|when|where|why|how|give|pull|open|check|help)\b/.test(
+    normalizedQuestion
+  )
+}
+
+function hasMeetingDataCue(normalizedQuestion: string): boolean {
+  return /\b(actions?|agenda|assigned|blockers?|calendar|calls?|decisions?|deadlines?|discussed|meetings?|notes?|recordings?|risks?|schedule|tasks?|transcripts?)\b/.test(
+    normalizedQuestion
+  )
+}
+
+function isCountConfirmationQuestion(
+  normalizedQuestion: string,
+  session: ChatConversationState
+): boolean {
+  if (/\bright now\b/.test(normalizedQuestion)) return false
+
+  const hasConfirmationCue = /\b(right|correct|accurate|then|total)\b/.test(normalizedQuestion)
+  const hasCountCue =
+    extractReferencedCount(normalizedQuestion) != null ||
+    /\b(how many|count|number of)\b/.test(normalizedQuestion)
+  const hasScopedSubjectCue = /\b(meetings?|recordings?|calls?|standups?|syncs?)\b/.test(
+    normalizedQuestion
+  )
+  const hasSingleImplicitScope =
+    (session.lastCalendarEvents.length > 0 && session.lastRecordingIds.length === 0) ||
+    (session.lastRecordingIds.length > 0 && session.lastCalendarEvents.length === 0)
+
+  return hasConfirmationCue && hasCountCue && (hasScopedSubjectCue || hasSingleImplicitScope)
+}
+
+function extractReferencedCount(normalizedQuestion: string): number | null {
+  const numeric = normalizedQuestion.match(/\b([0-9]{1,3})(?:st|nd|rd|th)?\b/)
+  if (numeric) return Number(numeric[1])
+
+  const wordCounts = new Map<string, number>([
+    ['one', 1],
+    ['two', 2],
+    ['three', 3],
+    ['four', 4],
+    ['five', 5],
+    ['six', 6],
+    ['seven', 7],
+    ['eight', 8],
+    ['nine', 9],
+    ['ten', 10]
+  ])
+  for (const [word, count] of wordCounts) {
+    if (new RegExp(`\\b${word}\\b`).test(normalizedQuestion)) return count
+  }
+  return null
+}
+
+function formatCountConfirmationAnswer(params: {
+  label: string
+  actualCount: number
+  referencedCount: number | null
+}): string {
+  const pluralLabel = `${params.label}${params.actualCount === 1 ? '' : 's'}`
+  if (params.referencedCount == null || params.referencedCount === params.actualCount) {
+    return `Yes, you have ${params.actualCount} ${pluralLabel} in that list.`
+  }
+  return `Not quite - you have ${params.actualCount} ${pluralLabel} in that list.`
+}
+
 function normalizeChatHistory(history: ChatHistoryMessage[]): ChatHistoryMessage[] {
   return history
     .filter(
@@ -766,11 +967,15 @@ function shouldStartNewConversationScope(question: string): boolean {
 
 function shouldUseConversationScope(question: string): boolean {
   const normalized = normalizeRecordingSearchText(question)
-  return isImplicitFollowUpQuestion(normalized) || hasContextReference(normalized)
+  return (
+    isImplicitFollowUpQuestion(normalized) ||
+    hasContextReference(normalized) ||
+    extractOrdinalReference(question) != null
+  )
 }
 
 function hasContextReference(normalizedQuestion: string): boolean {
-  return /\b(it|that|those|these|them|there|same|above|previous|earlier|for me|for us|the list|that list|this meeting|that meeting|these meetings|those meetings)\b/.test(
+  return /\b(it|that|those|these|them|there|same|above|previous|earlier|first|second|third|fourth|fifth|sixth|seventh|eighth|ninth|tenth|for me|for us|the list|that list|this meeting|that meeting|these meetings|those meetings)\b/.test(
     normalizedQuestion
   )
 }
@@ -791,7 +996,19 @@ function resolveScopedRecordingIds(question: string, session: ChatConversationSt
     return session.focusedRecordingIds
   }
 
+  if (session.lastRecordingIds.length > 0 && isImplicitFollowUpQuestion(normalized)) {
+    return session.lastRecordingIds
+  }
+
   return []
+}
+
+function mergeScopedRecordingIds(previousIds: string[], selectedIds: string[]): string[] {
+  if (previousIds.length === 0) return selectedIds
+  if (selectedIds.length === 0) return previousIds
+  const missingSelectedIds = selectedIds.filter((id) => !previousIds.includes(id))
+  if (missingSelectedIds.length > 0) return [...previousIds, ...missingSelectedIds]
+  return previousIds
 }
 
 function extractOrdinalReference(question: string): number | null {
@@ -800,15 +1017,25 @@ function extractOrdinalReference(question: string): number | null {
   if (numeric) return Number(numeric[1]) - 1
 
   const ordinals: Array<[RegExp, number]> = [
+    [/\b1st\b/, 0],
     [/\bfirst\b/, 0],
+    [/\b2nd\b/, 1],
     [/\bsecond\b/, 1],
+    [/\b3rd\b/, 2],
     [/\bthird\b/, 2],
+    [/\b4th\b/, 3],
     [/\bfourth\b/, 3],
+    [/\b5th\b/, 4],
     [/\bfifth\b/, 4],
+    [/\b6th\b/, 5],
     [/\bsixth\b/, 5],
+    [/\b7th\b/, 6],
     [/\bseventh\b/, 6],
+    [/\b8th\b/, 7],
     [/\beighth\b/, 7],
+    [/\b9th\b/, 8],
     [/\bninth\b/, 8],
+    [/\b10th\b/, 9],
     [/\btenth\b/, 9]
   ]
   return ordinals.find(([pattern]) => pattern.test(normalized))?.[1] ?? null
@@ -860,7 +1087,23 @@ function hasFreshSearchTerms(normalizedQuestion: string): boolean {
     'todo',
     'todos',
     'transcript',
-    'transcripts'
+    'transcripts',
+    'appreciate',
+    'awesome',
+    'can',
+    'cool',
+    'could',
+    'got',
+    'ok',
+    'okay',
+    'please',
+    'show',
+    'sounds',
+    'thank',
+    'thanks',
+    'thx',
+    'would',
+    'you'
   ])
 
   return extractQuestionTerms(normalizedQuestion).some((term) => !genericFollowUpTerms.has(term))
@@ -945,6 +1188,8 @@ function logChatRetrieval(params: {
         matchedCount: 0,
         selectedContextCount: 0,
         matchMode: 'ranked',
+        matchedMeetingIds: [],
+        matchedTitles: [],
         selectedMeetingIds: [],
         selectedTitles: [],
         inventoryElapsedMs: 0,

--- a/src/main/ipc/chat-ipc.ts
+++ b/src/main/ipc/chat-ipc.ts
@@ -16,6 +16,7 @@ import {
 } from '../services/chat-retrieval'
 import { normalizeRecordingSearchText } from '../services/recording-title'
 import { OllamaEmbeddingProvider } from '../services/ollama-embedding'
+import { classifyChatTurn, type ChatTurnSession } from '../services/chat-turn-classifier'
 
 const CHAT_SYSTEM_PROMPT = `You are AutoDoc's AI assistant. You help users understand their meetings by answering questions based on meeting transcripts, notes, and their calendar.
 
@@ -77,6 +78,7 @@ interface ChatHistoryMessage {
 interface ChatConversationState {
   lastCalendarEvents: CalendarEvent[]
   lastRecordingIds: string[]
+  lastRecordingTitles: string[]
   focusedRecordingIds: string[]
   lastClarificationOptions: ChatClarificationOption[]
 }
@@ -108,6 +110,10 @@ interface ChatErrorPayload {
   error: string
 }
 
+interface ChatCanceledPayload {
+  requestId: string
+}
+
 interface PreparedChatContext {
   directAnswer: string | null
   context: string
@@ -128,6 +134,7 @@ export function registerChatIpc(
     embeddingCachePath: join(app.getPath('userData'), 'cache', 'ask-ai-embeddings.json')
   })
   const chatSessions = new Map<number, ChatConversationState>()
+  const activeChatRequests = new Map<string, AbortController>()
   let calendarFailureUntil = 0
 
   const loadCalendarContextDataWithBackoff = async (): Promise<{
@@ -166,14 +173,16 @@ export function registerChatIpc(
   const prepareChatContext = async (
     question: string,
     history: ChatHistoryMessage[],
-    session: ChatConversationState
+    session: ChatConversationState,
+    signal?: AbortSignal
   ): Promise<{
     directAnswer: string | null
     context: string
     clarificationOptions?: ChatClarificationOption[]
   }> => {
-    const acknowledgementAnswer = buildAcknowledgementAnswer(question, history)
-    if (acknowledgementAnswer) {
+    const turn = classifyChatTurn(question, history, toClassifierSession(session))
+
+    if (turn.kind === 'acknowledgement') {
       logAutodocEvent({
         area: 'chat',
         message: 'chat routed without retrieval',
@@ -182,29 +191,58 @@ export function registerChatIpc(
           questionLength: question.length
         }
       })
-      return { directAnswer: acknowledgementAnswer, context: '' }
+      return { directAnswer: "You're welcome.", context: '' }
     }
 
-    const countConfirmationAnswer = buildCountConfirmationAnswer(question, session)
-    if (countConfirmationAnswer) {
+    if (turn.kind === 'smalltalk') {
+      logAutodocEvent({
+        area: 'chat',
+        message: 'chat routed without retrieval',
+        context: { route: 'smalltalk', topic: turn.topic, questionLength: question.length }
+      })
+      return { directAnswer: buildSmalltalkAnswer(turn.topic), context: '' }
+    }
+
+    if (turn.kind === 'count_confirmation') {
+      const directAnswer = formatCountConfirmationAnswer({
+        label: turn.scope === 'calendar' ? 'calendar meeting' : 'local recording',
+        actualCount:
+          turn.scope === 'calendar'
+            ? session.lastCalendarEvents.length
+            : session.lastRecordingIds.length,
+        referencedCount: turn.referencedCount
+      })
       logAutodocEvent({
         area: 'chat',
         message: 'chat routed without retrieval',
         context: {
           route: 'count-confirmation',
+          scope: turn.scope,
           questionLength: question.length,
           previousCalendarCount: session.lastCalendarEvents.length,
           previousRecordingCount: session.lastRecordingIds.length
         }
       })
-      return { directAnswer: countConfirmationAnswer, context: '' }
+      return { directAnswer, context: '' }
+    }
+
+    if (turn.kind === 'reference') {
+      return prepareMeetingScopedContext(question, turn.meetingIds, session, turn.followUp)
+    }
+
+    if (turn.kind === 'scoped_followup') {
+      return prepareMeetingScopedContext(question, turn.meetingIds, session, true)
     }
 
     const intent = detectChatIntent(question)
     if (intent === 'count' || intent === 'list') {
       clearConversationScope(session)
       const meetingContext = await recordingIndex.buildContext(question, [])
-      session.lastRecordingIds = meetingContext.diagnostics.matchedMeetingIds
+      rememberRecordingList(
+        session,
+        meetingContext.diagnostics.matchedMeetingIds,
+        meetingContext.diagnostics.matchedTitles
+      )
       session.focusedRecordingIds = []
       updateClarificationState(session, meetingContext)
       logAutodocEvent({
@@ -230,7 +268,11 @@ export function registerChatIpc(
     const localExactContext = await recordingIndex.buildExactTitleContext(question, [])
     if (localExactContext) {
       session.lastCalendarEvents = []
-      session.lastRecordingIds = localExactContext.diagnostics.selectedMeetingIds
+      rememberRecordingList(
+        session,
+        localExactContext.diagnostics.selectedMeetingIds,
+        localExactContext.diagnostics.selectedTitles
+      )
       session.focusedRecordingIds = localExactContext.diagnostics.selectedMeetingIds
       updateClarificationState(session, localExactContext)
       logAutodocEvent({
@@ -275,7 +317,8 @@ export function registerChatIpc(
         baseUrl: ollamaManager.getBaseUrl(),
         model: ollamaProvider.getModel(),
         question,
-        history
+        history,
+        signal
       })
       const plannedContext = await preparePlannedChatContext(question, plan, 'model', session)
       if (plannedContext.directAnswer || plannedContext.context.trim().length > 0) {
@@ -332,45 +375,53 @@ export function registerChatIpc(
     }
   }
 
+  // Recording coreference / implicit follow-ups are resolved up front by the
+  // turn classifier; this builds the answer for the recordings it selected.
+  const prepareMeetingScopedContext = async (
+    question: string,
+    meetingIds: string[],
+    session: ChatConversationState,
+    followUp: boolean
+  ): Promise<PreparedChatContext> => {
+    const meetingContext = await recordingIndex.buildContextForMeetingIds(
+      buildScopedQuestion(question, session, followUp),
+      meetingIds,
+      session.lastCalendarEvents
+    )
+    session.lastRecordingIds = mergeScopedRecordingIds(
+      session.lastRecordingIds,
+      meetingContext.diagnostics.selectedMeetingIds
+    )
+    session.focusedRecordingIds = meetingContext.diagnostics.selectedMeetingIds
+    updateClarificationState(session, meetingContext)
+    logAutodocEvent({
+      area: 'chat',
+      message: 'chat retrieval completed',
+      context: {
+        ...meetingContext.diagnostics,
+        conversationScopedFollowUp: true,
+        scopedToFocusedRecordings: true,
+        calendarElapsedMs: 0,
+        calendarSkippedByBackoff: false,
+        calendarRecentCount: session.lastCalendarEvents.length,
+        calendarUpcomingCount: 0
+      }
+    })
+    return {
+      directAnswer: meetingContext.directAnswer,
+      context: meetingContext.context,
+      clarificationOptions: meetingContext.clarificationOptions
+    }
+  }
+
+  // Calendar-list follow-ups (e.g. "which of those had notes?") remain here;
+  // recording references/follow-ups are handled by the classifier dispatch.
   const prepareConversationScopedContext = async (
     question: string,
     session: ChatConversationState
   ): Promise<PreparedChatContext | null> => {
+    if (session.lastCalendarEvents.length === 0) return null
     if (shouldStartNewConversationScope(question)) return null
-
-    const scopedIds = resolveScopedRecordingIds(question, session)
-    if (scopedIds.length > 0 && shouldUseConversationScope(question)) {
-      const meetingContext = await recordingIndex.buildContextForMeetingIds(
-        buildScopedQuestion(question, session),
-        scopedIds,
-        session.lastCalendarEvents
-      )
-      session.lastRecordingIds = mergeScopedRecordingIds(
-        session.lastRecordingIds,
-        meetingContext.diagnostics.selectedMeetingIds
-      )
-      session.focusedRecordingIds = meetingContext.diagnostics.selectedMeetingIds
-      updateClarificationState(session, meetingContext)
-      logAutodocEvent({
-        area: 'chat',
-        message: 'chat retrieval completed',
-        context: {
-          ...meetingContext.diagnostics,
-          conversationScopedFollowUp: true,
-          scopedToFocusedRecordings: true,
-          calendarElapsedMs: 0,
-          calendarSkippedByBackoff: false,
-          calendarRecentCount: session.lastCalendarEvents.length,
-          calendarUpcomingCount: 0
-        }
-      })
-      return {
-        directAnswer: meetingContext.directAnswer,
-        context: meetingContext.context,
-        clarificationOptions: meetingContext.clarificationOptions
-      }
-    }
-
     if (hasFreshSearchTerms(normalizeRecordingSearchText(question))) return null
 
     if (asksForNotesInPreviousSet(question) && session.lastCalendarEvents.length > 0) {
@@ -560,6 +611,14 @@ export function registerChatIpc(
     clearConversationScope(session)
   })
 
+  ipcMain.handle('chat:cancel', (_event, requestId: string): void => {
+    const controller = activeChatRequests.get(requestId)
+    if (controller) {
+      controller.abort()
+      activeChatRequests.delete(requestId)
+    }
+  })
+
   ipcMain.handle(
     'chat:send-stream',
     async (
@@ -570,6 +629,8 @@ export function registerChatIpc(
     ): Promise<void> => {
       const sender = event.sender
       const session = getChatSession(chatSessions, sender.id)
+      const controller = new AbortController()
+      activeChatRequests.set(requestId, controller)
       let normalizedHistoryLength = 0
 
       try {
@@ -578,7 +639,8 @@ export function registerChatIpc(
         const { directAnswer, context, clarificationOptions } = await prepareChatContext(
           question,
           normalizedHistory,
-          session
+          session,
+          controller.signal
         )
         if (directAnswer) {
           sender.send('chat:chunk', {
@@ -601,6 +663,7 @@ export function registerChatIpc(
           question,
           context,
           history: normalizedHistory,
+          signal: controller.signal,
           onChunk: (chunk) => {
             content += chunk
             sender.send('chat:chunk', { requestId, content: chunk } satisfies ChatStreamPayload)
@@ -608,6 +671,10 @@ export function registerChatIpc(
         })
         sender.send('chat:done', { requestId, content } satisfies ChatDonePayload)
       } catch (error) {
+        if (isAbortError(error) || controller.signal.aborted) {
+          sender.send('chat:canceled', { requestId } satisfies ChatCanceledPayload)
+          return
+        }
         logChatFailure(error, {
           requestId,
           route: 'chat:send-stream',
@@ -618,6 +685,8 @@ export function registerChatIpc(
           requestId,
           error: error instanceof Error ? error.message : String(error)
         } satisfies ChatErrorPayload)
+      } finally {
+        activeChatRequests.delete(requestId)
       }
     }
   )
@@ -633,6 +702,8 @@ export function registerChatIpc(
     ): Promise<void> => {
       const sender = event.sender
       const session = getChatSession(chatSessions, sender.id)
+      const controller = new AbortController()
+      activeChatRequests.set(requestId, controller)
       let normalizedHistoryLength = 0
 
       try {
@@ -680,6 +751,7 @@ export function registerChatIpc(
           question,
           context: meetingContext.context,
           history: normalizedHistory,
+          signal: controller.signal,
           onChunk: (chunk) => {
             content += chunk
             sender.send('chat:chunk', { requestId, content: chunk } satisfies ChatStreamPayload)
@@ -687,6 +759,10 @@ export function registerChatIpc(
         })
         sender.send('chat:done', { requestId, content } satisfies ChatDonePayload)
       } catch (error) {
+        if (isAbortError(error) || controller.signal.aborted) {
+          sender.send('chat:canceled', { requestId } satisfies ChatCanceledPayload)
+          return
+        }
         logChatFailure(error, {
           requestId,
           route: 'chat:select-recording-stream',
@@ -698,9 +774,15 @@ export function registerChatIpc(
           requestId,
           error: error instanceof Error ? error.message : String(error)
         } satisfies ChatErrorPayload)
+      } finally {
+        activeChatRequests.delete(requestId)
       }
     }
   )
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && (error.name === 'AbortError' || error.name === 'TimeoutError')
 }
 
 function logChatFailure(
@@ -731,6 +813,7 @@ function getChatSession(
     session = {
       lastCalendarEvents: [],
       lastRecordingIds: [],
+      lastRecordingTitles: [],
       focusedRecordingIds: [],
       lastClarificationOptions: []
     }
@@ -742,6 +825,7 @@ function getChatSession(
 function clearConversationScope(session: ChatConversationState): void {
   session.lastCalendarEvents = []
   session.lastRecordingIds = []
+  session.lastRecordingTitles = []
   session.focusedRecordingIds = []
   session.lastClarificationOptions = []
 }
@@ -753,159 +837,30 @@ function updateClarificationState(
   session.lastClarificationOptions = result.clarificationOptions ?? []
 }
 
-function buildAcknowledgementAnswer(
-  question: string,
-  history: ChatHistoryMessage[]
-): string | null {
-  const normalized = normalizeRecordingSearchText(question)
-  if (!normalized) return null
-  if (hasRequestCue(normalized) || hasMeetingDataCue(normalized)) return null
-
-  const tokens = normalized.split(' ').filter(Boolean)
-  if (tokens.length === 0 || tokens.length > 8) return null
-
-  const nonAckTokens = tokens.filter((token) => !ACKNOWLEDGEMENT_TERMS.has(token))
-  if (nonAckTokens.length > 0) return null
-
-  const hasPriorAssistantTurn = history.some((message) => message.role === 'assistant')
-  if (!hasPriorAssistantTurn && !tokens.some((token) => token === 'thanks' || token === 'thank')) {
-    return null
+function toClassifierSession(session: ChatConversationState): ChatTurnSession {
+  return {
+    recordingIds: session.lastRecordingIds,
+    recordingTitles: session.lastRecordingTitles,
+    calendarEventCount: session.lastCalendarEvents.length,
+    focusedRecordingIds: session.focusedRecordingIds,
+    lastTurnWasClarification: session.lastClarificationOptions.length > 0
   }
-
-  return "You're welcome."
 }
 
-function buildCountConfirmationAnswer(
-  question: string,
-  session: ChatConversationState
-): string | null {
-  const normalized = normalizeRecordingSearchText(question)
-  if (!isCountConfirmationQuestion(normalized, session)) return null
-
-  const referencedCount = extractReferencedCount(normalized)
-  if (/\brecordings?\b/.test(normalized) && session.lastRecordingIds.length > 0) {
-    return formatCountConfirmationAnswer({
-      label: 'local recording',
-      actualCount: session.lastRecordingIds.length,
-      referencedCount
-    })
-  }
-
-  if (/\b(meetings?|calls?|standups?|syncs?)\b/.test(normalized)) {
-    if (session.lastCalendarEvents.length > 0) {
-      return formatCountConfirmationAnswer({
-        label: 'calendar meeting',
-        actualCount: session.lastCalendarEvents.length,
-        referencedCount
-      })
-    }
-
-    if (session.lastRecordingIds.length > 0) {
-      return formatCountConfirmationAnswer({
-        label: 'local recording',
-        actualCount: session.lastRecordingIds.length,
-        referencedCount
-      })
-    }
-  }
-
-  if (!/\b(meetings?|recordings?|calls?|standups?|syncs?)\b/.test(normalized)) {
-    if (session.lastCalendarEvents.length > 0 && session.lastRecordingIds.length === 0) {
-      return formatCountConfirmationAnswer({
-        label: 'calendar meeting',
-        actualCount: session.lastCalendarEvents.length,
-        referencedCount
-      })
-    }
-
-    if (session.lastRecordingIds.length > 0 && session.lastCalendarEvents.length === 0) {
-      return formatCountConfirmationAnswer({
-        label: 'local recording',
-        actualCount: session.lastRecordingIds.length,
-        referencedCount
-      })
-    }
-  }
-
-  return null
+function rememberRecordingList(
+  session: ChatConversationState,
+  ids: string[],
+  titles: string[]
+): void {
+  session.lastRecordingIds = ids
+  session.lastRecordingTitles = titles
 }
 
-const ACKNOWLEDGEMENT_TERMS = new Set([
-  'amazing',
-  'appreciate',
-  'appreciated',
-  'awesome',
-  'cool',
-  'good',
-  'got',
-  'great',
-  'it',
-  'nice',
-  'ok',
-  'okay',
-  'perfect',
-  'sounds',
-  'sweet',
-  'thank',
-  'thanks',
-  'thx',
-  'yep',
-  'yes',
-  'you'
-])
-
-function hasRequestCue(normalizedQuestion: string): boolean {
-  return /\b(can|could|would|please|show|list|summarize|summary|recap|find|search|tell|explain|what|which|who|when|where|why|how|give|pull|open|check|help)\b/.test(
-    normalizedQuestion
-  )
-}
-
-function hasMeetingDataCue(normalizedQuestion: string): boolean {
-  return /\b(actions?|agenda|assigned|blockers?|calendar|calls?|decisions?|deadlines?|discussed|meetings?|notes?|recordings?|risks?|schedule|tasks?|transcripts?)\b/.test(
-    normalizedQuestion
-  )
-}
-
-function isCountConfirmationQuestion(
-  normalizedQuestion: string,
-  session: ChatConversationState
-): boolean {
-  if (/\bright now\b/.test(normalizedQuestion)) return false
-
-  const hasConfirmationCue = /\b(right|correct|accurate|then|total)\b/.test(normalizedQuestion)
-  const hasCountCue =
-    extractReferencedCount(normalizedQuestion) != null ||
-    /\b(how many|count|number of)\b/.test(normalizedQuestion)
-  const hasScopedSubjectCue = /\b(meetings?|recordings?|calls?|standups?|syncs?)\b/.test(
-    normalizedQuestion
-  )
-  const hasSingleImplicitScope =
-    (session.lastCalendarEvents.length > 0 && session.lastRecordingIds.length === 0) ||
-    (session.lastRecordingIds.length > 0 && session.lastCalendarEvents.length === 0)
-
-  return hasConfirmationCue && hasCountCue && (hasScopedSubjectCue || hasSingleImplicitScope)
-}
-
-function extractReferencedCount(normalizedQuestion: string): number | null {
-  const numeric = normalizedQuestion.match(/\b([0-9]{1,3})(?:st|nd|rd|th)?\b/)
-  if (numeric) return Number(numeric[1])
-
-  const wordCounts = new Map<string, number>([
-    ['one', 1],
-    ['two', 2],
-    ['three', 3],
-    ['four', 4],
-    ['five', 5],
-    ['six', 6],
-    ['seven', 7],
-    ['eight', 8],
-    ['nine', 9],
-    ['ten', 10]
-  ])
-  for (const [word, count] of wordCounts) {
-    if (new RegExp(`\\b${word}\\b`).test(normalizedQuestion)) return count
+function buildSmalltalkAnswer(topic: 'greeting' | 'capability'): string {
+  if (topic === 'capability') {
+    return "I'm AutoDoc's meeting assistant. Ask me what was discussed in a meeting, who owns an action item, decisions and deadlines, or what's on your calendar — I'll answer from your local recordings and notes."
   }
-  return null
+  return 'Hi! Ask me anything about your meetings — what was discussed, your action items and owners, or what you have coming up on your calendar.'
 }
 
 function formatCountConfirmationAnswer(params: {
@@ -983,24 +938,6 @@ function hasContextReference(normalizedQuestion: string): boolean {
 function isShortContextualQuestion(normalizedQuestion: string): boolean {
   const words = normalizedQuestion.split(' ').filter(Boolean)
   return words.length > 0 && words.length <= 8
-}
-
-function resolveScopedRecordingIds(question: string, session: ChatConversationState): string[] {
-  const ordinalIndex = extractOrdinalReference(question)
-  if (ordinalIndex != null && session.lastRecordingIds[ordinalIndex]) {
-    return [session.lastRecordingIds[ordinalIndex]]
-  }
-
-  const normalized = normalizeRecordingSearchText(question)
-  if (session.focusedRecordingIds.length > 0 && isImplicitFollowUpQuestion(normalized)) {
-    return session.focusedRecordingIds
-  }
-
-  if (session.lastRecordingIds.length > 0 && isImplicitFollowUpQuestion(normalized)) {
-    return session.lastRecordingIds
-  }
-
-  return []
 }
 
 function mergeScopedRecordingIds(previousIds: string[], selectedIds: string[]): string[] {
@@ -1109,8 +1046,12 @@ function hasFreshSearchTerms(normalizedQuestion: string): boolean {
   return extractQuestionTerms(normalizedQuestion).some((term) => !genericFollowUpTerms.has(term))
 }
 
-function buildScopedQuestion(question: string, session: ChatConversationState): string {
-  if (isImplicitFollowUpQuestion(normalizeRecordingSearchText(question))) {
+function buildScopedQuestion(
+  question: string,
+  session: ChatConversationState,
+  followUp: boolean
+): string {
+  if (followUp) {
     return `${question} Summarize any additional relevant notes from the selected meeting.`
   }
   if (session.lastRecordingIds.length > 0) {
@@ -1554,11 +1495,13 @@ async function buildChatRetrievalPlan(params: {
   model: string
   question: string
   history: ChatHistoryMessage[]
+  signal?: AbortSignal
 }): Promise<ChatRetrievalPlan> {
   try {
     const res = await fetch(`${params.baseUrl}/api/chat`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
+      signal: params.signal,
       body: JSON.stringify({
         model: params.model,
         messages: buildPlannerMessages(params.question, params.history),
@@ -1576,7 +1519,8 @@ async function buildChatRetrievalPlan(params: {
     if (!res.ok) throw new Error(`Ollama returned ${res.status}`)
     const data = (await res.json()) as { message?: { content?: string } }
     return parseChatRetrievalPlan(data.message?.content ?? '', params.question)
-  } catch {
+  } catch (error) {
+    if (params.signal?.aborted) throw error
     return buildFallbackRetrievalPlan(params.question)
   }
 }
@@ -1780,10 +1724,12 @@ async function streamOllamaChat(params: {
   context: string
   history: ChatHistoryMessage[]
   onChunk: (chunk: string) => void
+  signal?: AbortSignal
 }): Promise<void> {
   const res = await fetch(`${params.baseUrl}/api/chat`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
+    signal: params.signal,
     body: JSON.stringify({
       model: params.model,
       messages: buildChatMessages(

--- a/src/main/ipc/chat-ipc.ts
+++ b/src/main/ipc/chat-ipc.ts
@@ -388,9 +388,10 @@ export function registerChatIpc(
       meetingIds,
       session.lastCalendarEvents
     )
-    session.lastRecordingIds = mergeScopedRecordingIds(
-      session.lastRecordingIds,
-      meetingContext.diagnostics.selectedMeetingIds
+    mergeScopedRecordingList(
+      session,
+      meetingContext.diagnostics.selectedMeetingIds,
+      meetingContext.diagnostics.selectedTitles
     )
     session.focusedRecordingIds = meetingContext.diagnostics.selectedMeetingIds
     updateClarificationState(session, meetingContext)
@@ -429,7 +430,11 @@ export function registerChatIpc(
         session.lastCalendarEvents,
         session.lastCalendarEvents
       )
-      session.lastRecordingIds = meetingContext.diagnostics.selectedMeetingIds
+      rememberRecordingList(
+        session,
+        meetingContext.diagnostics.selectedMeetingIds,
+        meetingContext.diagnostics.selectedTitles
+      )
       session.focusedRecordingIds = meetingContext.diagnostics.selectedMeetingIds
       updateClarificationState(session, meetingContext)
       logAutodocEvent({
@@ -457,7 +462,11 @@ export function registerChatIpc(
         session.lastCalendarEvents,
         session.lastCalendarEvents
       )
-      session.lastRecordingIds = meetingContext.diagnostics.selectedMeetingIds
+      rememberRecordingList(
+        session,
+        meetingContext.diagnostics.selectedMeetingIds,
+        meetingContext.diagnostics.selectedTitles
+      )
       session.focusedRecordingIds = meetingContext.diagnostics.selectedMeetingIds
       updateClarificationState(session, meetingContext)
       logAutodocEvent({
@@ -541,7 +550,7 @@ export function registerChatIpc(
         calendarUpcomingCount
       })
       session.lastCalendarEvents = selectedCalendarEvents
-      session.lastRecordingIds = []
+      rememberRecordingList(session, [], [])
       session.focusedRecordingIds = []
       session.lastClarificationOptions = []
       return { directAnswer, context: '' }
@@ -565,7 +574,11 @@ export function registerChatIpc(
       if (meetingContext.context) contextParts.push(meetingContext.context)
       if (meetingContext.directAnswer)
         contextParts.push(`Local recording answer: ${meetingContext.directAnswer}`)
-      session.lastRecordingIds = meetingContext.diagnostics.selectedMeetingIds
+      rememberRecordingList(
+        session,
+        meetingContext.diagnostics.selectedMeetingIds,
+        meetingContext.diagnostics.selectedTitles
+      )
       session.focusedRecordingIds = meetingContext.diagnostics.selectedMeetingIds
       updateClarificationState(session, meetingContext)
       if (selectedCalendarEvents.length > 0) {
@@ -714,7 +727,11 @@ export function registerChatIpc(
           [meetingId],
           session.lastCalendarEvents
         )
-        session.lastRecordingIds = meetingContext.diagnostics.selectedMeetingIds
+        rememberRecordingList(
+          session,
+          meetingContext.diagnostics.selectedMeetingIds,
+          meetingContext.diagnostics.selectedTitles
+        )
         session.focusedRecordingIds = meetingContext.diagnostics.selectedMeetingIds
         updateClarificationState(session, meetingContext)
         logAutodocEvent({
@@ -852,8 +869,9 @@ function rememberRecordingList(
   ids: string[],
   titles: string[]
 ): void {
+  // Keep the two arrays index-aligned so title coreference resolves the right id.
   session.lastRecordingIds = ids
-  session.lastRecordingTitles = titles
+  session.lastRecordingTitles = ids.map((_, index) => titles[index] ?? '')
 }
 
 function buildSmalltalkAnswer(topic: 'greeting' | 'capability'): string {
@@ -940,12 +958,26 @@ function isShortContextualQuestion(normalizedQuestion: string): boolean {
   return words.length > 0 && words.length <= 8
 }
 
-function mergeScopedRecordingIds(previousIds: string[], selectedIds: string[]): string[] {
-  if (previousIds.length === 0) return selectedIds
-  if (selectedIds.length === 0) return previousIds
-  const missingSelectedIds = selectedIds.filter((id) => !previousIds.includes(id))
-  if (missingSelectedIds.length > 0) return [...previousIds, ...missingSelectedIds]
-  return previousIds
+function mergeScopedRecordingList(
+  session: ChatConversationState,
+  selectedIds: string[],
+  selectedTitles: string[]
+): void {
+  if (session.lastRecordingIds.length === 0) {
+    rememberRecordingList(session, selectedIds, selectedTitles)
+    return
+  }
+  if (selectedIds.length === 0) return
+
+  const mergedIds = [...session.lastRecordingIds]
+  const mergedTitles = [...session.lastRecordingTitles]
+  selectedIds.forEach((id, index) => {
+    if (!mergedIds.includes(id)) {
+      mergedIds.push(id)
+      mergedTitles.push(selectedTitles[index] ?? '')
+    }
+  })
+  rememberRecordingList(session, mergedIds, mergedTitles)
 }
 
 function extractOrdinalReference(question: string): number | null {

--- a/src/main/services/__tests__/chat-retrieval.test.ts
+++ b/src/main/services/__tests__/chat-retrieval.test.ts
@@ -1,7 +1,7 @@
 import { mkdtemp, rm, mkdir, writeFile, utimes } from 'fs/promises'
 import { join } from 'path'
 import { tmpdir } from 'os'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type {
   CalendarEvent,
   MeetingMetadata,
@@ -16,7 +16,13 @@ import {
 
 const tempDirs: string[] = []
 
+beforeEach(() => {
+  vi.useFakeTimers({ toFake: ['Date'] })
+  vi.setSystemTime(new Date(2026, 4, 27, 12, 0))
+})
+
 afterEach(async () => {
+  vi.useRealTimers()
   await Promise.all(tempDirs.map((dir) => rm(dir, { recursive: true, force: true })))
   tempDirs.length = 0
 })
@@ -137,9 +143,12 @@ describe('ChatRecordingIndex', () => {
     expect(count.directAnswer).toBe('You have 100 recordings.')
     expect(count.diagnostics.matchMode).toBe('direct-count')
     expect(count.diagnostics.selectedContextCount).toBe(0)
+    expect(count.diagnostics.matchedMeetingIds).toHaveLength(100)
     expect(list.directAnswer).toContain('I found 100 recordings total')
     expect(list.directAnswer).toContain('showed the most recent 50')
     expect(list.diagnostics.inventoryCount).toBe(100)
+    expect(list.diagnostics.selectedContextCount).toBe(0)
+    expect(list.diagnostics.matchedMeetingIds).toHaveLength(100)
   })
 
   it('applies direct count and list qualifiers before answering', async () => {

--- a/src/main/services/__tests__/chat-turn-classifier.test.ts
+++ b/src/main/services/__tests__/chat-turn-classifier.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from 'vitest'
+import {
+  classifyChatTurn,
+  extractReferencedCount,
+  hasFreshSearchTerms,
+  isImplicitFollowUp,
+  resolveOrdinalIndex,
+  resolveTitleReference,
+  type ChatTurnSession
+} from '../chat-turn-classifier'
+
+const LISTED: ChatTurnSession = {
+  recordingIds: ['r-roadmap', 'r-support', 'r-design', 'r-calendar'],
+  recordingTitles: ['Roadmap Review', 'Support Triage', 'Design Sync', 'Calendar Auth Review'],
+  calendarEventCount: 0,
+  focusedRecordingIds: [],
+  lastTurnWasClarification: false
+}
+
+const PRIOR_LIST_HISTORY = [
+  { role: 'user' as const, content: 'list my recordings' },
+  { role: 'assistant' as const, content: 'Here are your recordings: ...' }
+]
+
+const emptySession = (): ChatTurnSession => ({
+  recordingIds: [],
+  recordingTitles: [],
+  calendarEventCount: 0,
+  focusedRecordingIds: [],
+  lastTurnWasClarification: false
+})
+
+describe('classifyChatTurn — acknowledgements', () => {
+  it('treats gratitude as an acknowledgement', () => {
+    for (const q of ['thanks!', 'ok cool', 'much appreciated', 'cheers', 'no worries, ty', 'thx']) {
+      expect(classifyChatTurn(q, PRIOR_LIST_HISTORY, LISTED).kind, q).toBe('acknowledgement')
+    }
+  })
+
+  it('does not swallow a mixed thanks+request as an acknowledgement', () => {
+    expect(
+      classifyChatTurn('thanks, can you show action items?', PRIOR_LIST_HISTORY, LISTED).kind
+    ).not.toBe('acknowledgement')
+  })
+
+  it('does not treat a bare affirmation answering a clarification as gratitude', () => {
+    const session = { ...emptySession(), lastTurnWasClarification: true }
+    const history = [
+      { role: 'user' as const, content: 'pull up the roadmap meeting' },
+      { role: 'assistant' as const, content: 'Which one should I use? 1. Roadmap 2. Design' }
+    ]
+    expect(classifyChatTurn('yes', history, session).kind).not.toBe('acknowledgement')
+    expect(classifyChatTurn('yep the first one', history, session).kind).not.toBe('acknowledgement')
+  })
+})
+
+describe('classifyChatTurn — small talk', () => {
+  it('routes greetings to small talk without retrieval', () => {
+    for (const q of ['hey', 'hi there', 'hello!', 'good morning', 'yo', 'how are you?']) {
+      expect(classifyChatTurn(q, [], emptySession()), q).toEqual({
+        kind: 'smalltalk',
+        topic: 'greeting'
+      })
+    }
+  })
+
+  it('routes capability questions to small talk', () => {
+    for (const q of ['what can you do?', 'who are you?', 'what is this?']) {
+      expect(classifyChatTurn(q, [], emptySession()), q).toEqual({
+        kind: 'smalltalk',
+        topic: 'capability'
+      })
+    }
+  })
+
+  it('does not treat a greeting glued to a real request as small talk', () => {
+    expect(
+      classifyChatTurn('hey what did we discuss in the design sync', [], LISTED).kind
+    ).not.toBe('smalltalk')
+    expect(classifyChatTurn('hi can you list my recordings', [], emptySession()).kind).not.toBe(
+      'smalltalk'
+    )
+  })
+})
+
+describe('classifyChatTurn — count confirmations', () => {
+  it('confirms an explicit count from session state', () => {
+    const turn = classifyChatTurn('so four then?', PRIOR_LIST_HISTORY, LISTED)
+    expect(turn).toEqual({ kind: 'count_confirmation', scope: 'recording', referencedCount: 4 })
+  })
+
+  it('handles implicit "is that all" and "only N" forms', () => {
+    expect(classifyChatTurn('is that all of them?', PRIOR_LIST_HISTORY, LISTED).kind).toBe(
+      'count_confirmation'
+    )
+    expect(classifyChatTurn('only 4?', PRIOR_LIST_HISTORY, LISTED)).toEqual({
+      kind: 'count_confirmation',
+      scope: 'recording',
+      referencedCount: 4
+    })
+  })
+
+  it('uses calendar scope when only calendar meetings were presented', () => {
+    const session: ChatTurnSession = { ...emptySession(), calendarEventCount: 8 }
+    const turn = classifyChatTurn('so 8 then?', PRIOR_LIST_HISTORY, session)
+    expect(turn).toEqual({ kind: 'count_confirmation', scope: 'calendar', referencedCount: 8 })
+  })
+
+  it('does not treat a real request containing a number as a confirmation', () => {
+    expect(classifyChatTurn('show me 2 action items', PRIOR_LIST_HISTORY, LISTED).kind).not.toBe(
+      'count_confirmation'
+    )
+  })
+})
+
+describe('classifyChatTurn — coreference', () => {
+  it('resolves ordinal words against the presented list', () => {
+    expect(
+      classifyChatTurn('show notes for the second one', PRIOR_LIST_HISTORY, LISTED)
+    ).toMatchObject({ kind: 'reference', meetingIds: ['r-support'] })
+    expect(classifyChatTurn('summarize the third one', PRIOR_LIST_HISTORY, LISTED)).toMatchObject({
+      kind: 'reference',
+      meetingIds: ['r-design']
+    })
+  })
+
+  it('resolves "the last one" to the final list item', () => {
+    expect(
+      classifyChatTurn('show notes for the last one', PRIOR_LIST_HISTORY, LISTED)
+    ).toMatchObject({ kind: 'reference', meetingIds: ['r-calendar'] })
+  })
+
+  it('resolves a title-style reference', () => {
+    expect(
+      classifyChatTurn('tell me about the calendar auth one', PRIOR_LIST_HISTORY, LISTED)
+    ).toMatchObject({ kind: 'reference', meetingIds: ['r-calendar'] })
+  })
+
+  it('treats a quantity as a quantity, never as the Nth list slot', () => {
+    // "3" is a quantity; the explicit "support meeting" should win, never the 3rd slot.
+    const top3 = classifyChatTurn(
+      'what are the top 3 action items from the support meeting?',
+      PRIOR_LIST_HISTORY,
+      LISTED
+    )
+    if (top3.kind === 'reference') {
+      expect(top3.meetingIds).toEqual(['r-support'])
+      expect(top3.meetingIds).not.toContain('r-design') // the 3rd slot
+    }
+
+    // "2" is a quantity; must never resolve to the 2nd slot (Support).
+    const takeaways = classifyChatTurn(
+      'give me 2 takeaways from the roadmap review',
+      PRIOR_LIST_HISTORY,
+      LISTED
+    )
+    if (takeaways.kind === 'reference') {
+      expect(takeaways.meetingIds).not.toContain('r-support')
+    }
+  })
+})
+
+describe('resolveOrdinalIndex', () => {
+  it('maps ordinal words and suffixed numerals only with a referential anchor', () => {
+    expect(resolveOrdinalIndex('the second one', 4)).toBe(1)
+    expect(resolveOrdinalIndex('the 3rd recording', 4)).toBe(2)
+    expect(resolveOrdinalIndex('the last one', 4)).toBe(3)
+    expect(resolveOrdinalIndex('number 2', 4)).toBe(1)
+  })
+
+  it('ignores bare quantities and out-of-range indices', () => {
+    expect(resolveOrdinalIndex('3 action items', 4)).toBeNull()
+    expect(resolveOrdinalIndex('2 takeaways', 4)).toBeNull()
+    expect(resolveOrdinalIndex('the 9th one', 4)).toBeNull()
+    expect(resolveOrdinalIndex('second quarter results', 4)).toBeNull()
+  })
+})
+
+describe('resolveTitleReference', () => {
+  it('returns the uniquely best-matching prior title', () => {
+    expect(resolveTitleReference('the calendar auth one', 'the calendar auth one', LISTED)).toEqual(
+      ['r-calendar']
+    )
+  })
+
+  it('returns null without a referential anchor', () => {
+    expect(resolveTitleReference('calendar auth scopes', 'calendar auth scopes', LISTED)).toBeNull()
+  })
+})
+
+describe('lexical helpers', () => {
+  it('extractReferencedCount reads digits and number words', () => {
+    expect(extractReferencedCount('so four then')).toBe(4)
+    expect(extractReferencedCount('only 7?')).toBe(7)
+    expect(extractReferencedCount('is that all')).toBeNull()
+  })
+
+  it('hasFreshSearchTerms ignores generic follow-up vocabulary', () => {
+    expect(hasFreshSearchTerms('show action items')).toBe(false)
+    expect(hasFreshSearchTerms('what about the billing migration')).toBe(true)
+  })
+
+  it('isImplicitFollowUp recognizes short contextual prompts', () => {
+    expect(isImplicitFollowUp('anything else?')).toBe(true)
+    expect(isImplicitFollowUp('show action items')).toBe(true)
+    expect(isImplicitFollowUp('who owns the billing migration checklist')).toBe(false)
+  })
+})
+
+describe('classifyChatTurn — fresh retrieval', () => {
+  it('routes brand-new scope questions to new_retrieval', () => {
+    expect(classifyChatTurn('what meetings did I have this week', [], LISTED).kind).toBe(
+      'new_retrieval'
+    )
+    expect(classifyChatTurn('list my recordings', [], emptySession()).kind).toBe('new_retrieval')
+  })
+})

--- a/src/main/services/chat-retrieval.ts
+++ b/src/main/services/chat-retrieval.ts
@@ -233,6 +233,8 @@ export interface ChatRetrievalDiagnostics {
   matchedCount: number
   selectedContextCount: number
   matchMode: 'direct-count' | 'direct-list' | 'large-all-guardrail' | 'exact-title' | 'ranked'
+  matchedMeetingIds: string[]
+  matchedTitles: string[]
   selectedMeetingIds: string[]
   selectedTitles: string[]
   inventoryElapsedMs: number
@@ -1505,6 +1507,8 @@ export class ChatRecordingIndex {
         matchedCount: params.matched.length,
         selectedContextCount: params.selected.length,
         matchMode: params.matchMode,
+        matchedMeetingIds: params.matched.map((meeting) => meeting.id),
+        matchedTitles: params.matched.map((meeting) => meeting.title),
         selectedMeetingIds: params.selected.map((meeting) => meeting.id),
         selectedTitles: params.selected.map((meeting) => meeting.title),
         inventoryElapsedMs: params.inventoryElapsedMs,

--- a/src/main/services/chat-turn-classifier.ts
+++ b/src/main/services/chat-turn-classifier.ts
@@ -1,0 +1,603 @@
+/**
+ * Ask AI turn classifier (AD-83).
+ *
+ * One place that decides what *kind* of conversational turn the user just sent,
+ * resolving coreference against the ordered list of recordings the user was last
+ * shown. This replaces the scattered, overlapping predicates that previously lived
+ * in `chat-ipc.ts` (acknowledgement detection, count-confirmation gating, ordinal
+ * extraction, implicit-follow-up detection, fresh-search-term detection, etc.),
+ * each of which maintained its own drifting vocabulary.
+ *
+ * Design goals:
+ *   - Single, ordered precedence so a turn resolves to exactly one kind.
+ *   - Shared lexicon (no duplicated word lists).
+ *   - Deterministic coreference against the *presented* ordered list, including
+ *     ordinal-vs-quantity disambiguation, "first/last", and title references.
+ *   - Affirmations answering a clarification are never mistaken for "thanks".
+ */
+import { extractQuestionTerms } from './chat-retrieval'
+import { normalizeRecordingSearchText } from './recording-title'
+
+export interface ChatTurnSession {
+  /** Ordered recording ids the user was last shown (most recent first). */
+  recordingIds: string[]
+  /** Ordered recording titles, parallel to recordingIds. */
+  recordingTitles: string[]
+  /** Number of calendar meetings in the last presented calendar list. */
+  calendarEventCount: number
+  /** Recordings currently in focus from the prior turn (drill-down target). */
+  focusedRecordingIds: string[]
+  /** True when the previous assistant turn asked a clarifying question. */
+  lastTurnWasClarification: boolean
+}
+
+export interface ChatHistoryTurn {
+  role: 'user' | 'assistant'
+  content: string
+}
+
+export type ClassifiedTurn =
+  | { kind: 'acknowledgement' }
+  | { kind: 'smalltalk'; topic: 'greeting' | 'capability' }
+  | { kind: 'count_confirmation'; scope: 'recording' | 'calendar'; referencedCount: number | null }
+  | { kind: 'reference'; meetingIds: string[]; followUp: boolean }
+  | { kind: 'scoped_followup'; meetingIds: string[] }
+  | { kind: 'new_retrieval' }
+
+// ---------------------------------------------------------------------------
+// Shared lexicon (single source of truth for all routing vocabulary)
+// ---------------------------------------------------------------------------
+
+/** Words that, on their own, signal gratitude / closing pleasantries. */
+const ACKNOWLEDGEMENT_TERMS = new Set([
+  'amazing',
+  'appreciate',
+  'appreciated',
+  'awesome',
+  'brilliant',
+  'cheers',
+  'cool',
+  'excellent',
+  'fantastic',
+  'good',
+  'got',
+  'great',
+  'helpful',
+  'it',
+  'lovely',
+  'much',
+  'neat',
+  'nice',
+  'no',
+  'ok',
+  'okay',
+  'perfect',
+  'sounds',
+  'super',
+  'sweet',
+  'ta',
+  'thank',
+  'thanks',
+  'thankyou',
+  'thx',
+  'ty',
+  'wonderful',
+  'worries',
+  'you'
+])
+
+/** Greeting / small-talk openers that do not need retrieval or the model. */
+const GREETING_TERMS = new Set([
+  'afternoon',
+  'evening',
+  'greetings',
+  'hello',
+  'hey',
+  'heya',
+  'hi',
+  'hiya',
+  'howdy',
+  'morning',
+  'sup',
+  'there',
+  'yo'
+])
+
+/** Words that affirm a prior assistant question (distinct from gratitude). */
+const AFFIRMATION_TERMS = new Set([
+  'affirmative',
+  'correct',
+  'right',
+  'sure',
+  'yea',
+  'yeah',
+  'yep',
+  'yes',
+  'yup'
+])
+
+/** Cues that the user is asking us to do or fetch something. */
+const REQUEST_CUE =
+  /\b(can|could|would|will|please|show|list|give|pull|open|find|search|tell|explain|summarize|summary|summarise|recap|describe|display|what|which|who|whom|when|where|why|how|check|help|need|want)\b/
+
+/** Cues that name meeting data the user wants. */
+const MEETING_DATA_CUE =
+  /\b(actions?|action items?|agenda|assigned|blockers?|calendar|calls?|decisions?|deadlines?|discussed|details?|meetings?|notes?|owners?|recordings?|risks?|schedule|standups?|status|syncs?|tasks?|todos?|transcripts?)\b/
+
+/** Generic follow-up vocabulary that does NOT count as a fresh search term. */
+const GENERIC_FOLLOWUP_TERMS = new Set([
+  'action',
+  'actions',
+  'assigned',
+  'blocker',
+  'blockers',
+  'deadline',
+  'deadlines',
+  'decision',
+  'decisions',
+  'detail',
+  'details',
+  'due',
+  'item',
+  'items',
+  'more',
+  'next',
+  'note',
+  'notes',
+  'owner',
+  'owners',
+  'owns',
+  'recap',
+  'risk',
+  'risks',
+  'status',
+  'step',
+  'steps',
+  'summary',
+  'summarize',
+  'task',
+  'tasks',
+  'todo',
+  'todos',
+  'transcript',
+  'transcripts',
+  // pleasantries that may be glued onto a follow-up
+  'appreciate',
+  'awesome',
+  'can',
+  'cheers',
+  'cool',
+  'could',
+  'got',
+  'great',
+  'ok',
+  'okay',
+  'please',
+  'show',
+  'sounds',
+  'thank',
+  'thanks',
+  'thx',
+  'ty',
+  'would',
+  'you'
+])
+
+/** Referential anchors that indicate a reference to a prior list item. */
+const REFERENTIAL_ANCHOR =
+  /\b(one|ones|recording|recordings|meeting|meetings|call|calls|standup|standups|sync|syncs|note|notes|item|items)\b/
+
+const ORDINAL_WORDS: Record<string, number> = {
+  first: 0,
+  second: 1,
+  third: 2,
+  fourth: 3,
+  fifth: 4,
+  sixth: 5,
+  seventh: 6,
+  eighth: 7,
+  ninth: 8,
+  tenth: 9
+}
+
+const NUMBER_WORDS: Record<string, number> = {
+  one: 1,
+  two: 2,
+  three: 3,
+  four: 4,
+  five: 5,
+  six: 6,
+  seven: 7,
+  eight: 8,
+  nine: 9,
+  ten: 10
+}
+
+/** Generic title tokens that never count as a distinctive title reference. */
+const GENERIC_TITLE_TOKENS = new Set([
+  'and',
+  'call',
+  'calls',
+  'fixture',
+  'meeting',
+  'meetings',
+  'recording',
+  'recordings',
+  'review',
+  'standup',
+  'standups',
+  'sync',
+  'syncs',
+  'the',
+  'with'
+])
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+export function classifyChatTurn(
+  question: string,
+  history: ChatHistoryTurn[],
+  session: ChatTurnSession
+): ClassifiedTurn {
+  const normalized = normalizeRecordingSearchText(question)
+  if (!normalized) return { kind: 'new_retrieval' }
+
+  // 1. A question that opens a brand-new scope is always a fresh retrieval.
+  if (startsNewScope(normalized)) return { kind: 'new_retrieval' }
+
+  const tokens = normalized.split(' ').filter(Boolean)
+  const hasPriorAssistantTurn = history.some((message) => message.role === 'assistant')
+
+  // 2. Pure acknowledgement ("thanks", "ok cool", "much appreciated").
+  if (isAcknowledgement(normalized, tokens, hasPriorAssistantTurn, session)) {
+    return { kind: 'acknowledgement' }
+  }
+
+  // 2b. Greetings / small talk ("hey", "good morning", "what can you do?").
+  const smalltalk = classifySmalltalk(normalized, tokens)
+  if (smalltalk) return smalltalk
+
+  // 3. Count confirmation ("so four then?", "only 4?", "is that all of them?").
+  const countConfirmation = classifyCountConfirmation(normalized, session)
+  if (countConfirmation) return countConfirmation
+
+  // 4. Direct coreference to a specific prior list item ("the second one",
+  //    "the last one", "the calendar auth one").
+  const referencedIds = resolveCoreference(normalized, question, session)
+  if (referencedIds && referencedIds.length > 0) {
+    return {
+      kind: 'reference',
+      meetingIds: referencedIds,
+      followUp: !hasFreshSearchTerms(normalized)
+    }
+  }
+
+  // 5. Implicit follow-up that reuses the prior scope ("anything else?",
+  //    "show action items") without naming a specific item.
+  const scopedIds = resolveScopedFollowUp(normalized, session)
+  if (scopedIds.length > 0) return { kind: 'scoped_followup', meetingIds: scopedIds }
+
+  // 6. Everything else is a fresh retrieval.
+  return { kind: 'new_retrieval' }
+}
+
+// ---------------------------------------------------------------------------
+// Precedence helpers
+// ---------------------------------------------------------------------------
+
+function startsNewScope(normalized: string): boolean {
+  if (
+    /\b(all recordings|every recording|recording inventory|library|all meetings|every meeting)\b/.test(
+      normalized
+    )
+  ) {
+    return true
+  }
+  if (
+    /\b(today|yesterday|last week|this week|this month|last month|upcoming|tomorrow)\b/.test(
+      normalized
+    )
+  ) {
+    return true
+  }
+  if (/\bnext (week|month|meeting|call)\b/.test(normalized)) return true
+  // "what/which meetings ..." inventory style openers start a new scope.
+  if (/\b(how many|number of)\b.*\b(meetings?|recordings?|calls?)\b/.test(normalized)) return true
+  return false
+}
+
+function isAcknowledgement(
+  normalized: string,
+  tokens: string[],
+  hasPriorAssistantTurn: boolean,
+  session: ChatTurnSession
+): boolean {
+  if (tokens.length === 0 || tokens.length > 8) return false
+  if (REQUEST_CUE.test(normalized) || MEETING_DATA_CUE.test(normalized)) return false
+
+  // An affirmation answering a clarifying question is NOT a "thank you".
+  const hasAffirmation = tokens.some((token) => AFFIRMATION_TERMS.has(token))
+  if (hasAffirmation && session.lastTurnWasClarification) return false
+
+  const leftover = tokens.filter(
+    (token) => !ACKNOWLEDGEMENT_TERMS.has(token) && !AFFIRMATION_TERMS.has(token)
+  )
+  if (leftover.length > 0) return false
+
+  // Pure-affirmation turns ("yes", "yep") are not acknowledgements on their own.
+  const hasGratitudeTerm = tokens.some((token) => ACKNOWLEDGEMENT_TERMS.has(token))
+  if (!hasGratitudeTerm) return false
+
+  const mentionsThanks = tokens.some((token) => isThanksToken(token))
+  if (!hasPriorAssistantTurn && !mentionsThanks) return false
+
+  return true
+}
+
+function classifySmalltalk(
+  normalized: string,
+  tokens: string[]
+): Extract<ClassifiedTurn, { kind: 'smalltalk' }> | null {
+  // Capability / identity questions are small talk even though they read as requests.
+  if (
+    /\b(what can you do|what do you do|what can you help|who are you|what are you|how do you work|what is this|what are your capabilities)\b/.test(
+      normalized
+    )
+  ) {
+    return { kind: 'smalltalk', topic: 'capability' }
+  }
+
+  if (tokens.length === 0 || tokens.length > 8) return null
+  if (MEETING_DATA_CUE.test(normalized)) return null
+
+  // Well-being / greeting phrases ("how are you?") read as requests because of
+  // "how", so they are matched before the generic request-cue guard.
+  const hasGreetingPhrase =
+    /\b(good morning|good afternoon|good evening|how are you|how are things|how have you been|hows it going|how is it going|whats up|hope you|nice to meet|long time)\b/.test(
+      normalized
+    )
+  if (hasGreetingPhrase && tokens.length <= 6) return { kind: 'smalltalk', topic: 'greeting' }
+
+  if (REQUEST_CUE.test(normalized)) return null
+
+  const hasGreetingWord = tokens.some((token) => GREETING_TERMS.has(token))
+  if (!hasGreetingWord) return null
+
+  // Every remaining token must be a greeting/pleasantry filler — otherwise it is
+  // a real prompt that merely opens with "hi".
+  const leftover = tokens.filter(
+    (token) =>
+      !GREETING_TERMS.has(token) &&
+      !ACKNOWLEDGEMENT_TERMS.has(token) &&
+      !SMALLTALK_FILLER.has(token)
+  )
+  if (leftover.length > 0) return null
+
+  return { kind: 'smalltalk', topic: 'greeting' }
+}
+
+const SMALLTALK_FILLER = new Set([
+  'are',
+  'be',
+  'doing',
+  'everyone',
+  'going',
+  'how',
+  'hows',
+  'is',
+  'it',
+  'long',
+  'meet',
+  'nice',
+  'there',
+  'things',
+  'time',
+  'to',
+  'up',
+  'whats',
+  'you'
+])
+
+function isThanksToken(token: string): boolean {
+  return (
+    token === 'thanks' ||
+    token === 'thank' ||
+    token === 'thankyou' ||
+    token === 'thx' ||
+    token === 'ty' ||
+    token === 'ta' ||
+    token === 'cheers'
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Count confirmation
+// ---------------------------------------------------------------------------
+
+function classifyCountConfirmation(
+  normalized: string,
+  session: ChatTurnSession
+): Extract<ClassifiedTurn, { kind: 'count_confirmation' }> | null {
+  if (/\bright now\b/.test(normalized)) return null
+  // Real requests (e.g. "show 4 of them") are not confirmations.
+  if (REQUEST_CUE.test(normalized) && !/\b(how many|number of)\b/.test(normalized)) return null
+
+  const referencedCount = extractReferencedCount(normalized)
+  const hasConfirmationCue =
+    /\b(right|correct|accurate|then|total|all|only|just)\b/.test(normalized) ||
+    /\b(is that all|that all|all of them|that it|thats it|is that it)\b/.test(normalized)
+  const hasCountCue =
+    referencedCount != null ||
+    /\b(how many|count|number of|all of them|that all|is that all)\b/.test(normalized)
+  if (!hasConfirmationCue || !hasCountCue) return null
+
+  const mentionsRecordings = /\brecordings?\b/.test(normalized)
+  const mentionsMeetings = /\b(meetings?|calls?|standups?|syncs?)\b/.test(normalized)
+  const hasRecordings = session.recordingIds.length > 0
+  const hasCalendar = session.calendarEventCount > 0
+
+  if (mentionsRecordings && hasRecordings) {
+    return { kind: 'count_confirmation', scope: 'recording', referencedCount }
+  }
+  if (mentionsMeetings) {
+    if (hasCalendar) return { kind: 'count_confirmation', scope: 'calendar', referencedCount }
+    if (hasRecordings) return { kind: 'count_confirmation', scope: 'recording', referencedCount }
+  }
+  if (!mentionsRecordings && !mentionsMeetings) {
+    // Implicit subject: use whichever single scope we presented last.
+    if (hasCalendar && !hasRecordings) {
+      return { kind: 'count_confirmation', scope: 'calendar', referencedCount }
+    }
+    if (hasRecordings && !hasCalendar) {
+      return { kind: 'count_confirmation', scope: 'recording', referencedCount }
+    }
+  }
+  return null
+}
+
+export function extractReferencedCount(normalized: string): number | null {
+  const numeric = normalized.match(/\b([0-9]{1,3})(?:st|nd|rd|th)?\b/)
+  if (numeric) return Number(numeric[1])
+  for (const [word, count] of Object.entries(NUMBER_WORDS)) {
+    if (new RegExp(`\\b${word}\\b`).test(normalized)) return count
+  }
+  return null
+}
+
+// ---------------------------------------------------------------------------
+// Coreference resolution (against the presented ordered list)
+// ---------------------------------------------------------------------------
+
+function resolveCoreference(
+  normalized: string,
+  rawQuestion: string,
+  session: ChatTurnSession
+): string[] | null {
+  const list = session.recordingIds
+  if (list.length === 0) return null
+
+  const ordinalIndex = resolveOrdinalIndex(normalized, list.length)
+  if (ordinalIndex != null) return [list[ordinalIndex]]
+
+  const titleIds = resolveTitleReference(normalized, rawQuestion, session)
+  if (titleIds && titleIds.length > 0) return titleIds
+
+  return null
+}
+
+/**
+ * Resolve an ordinal reference to a 0-based index, or null.
+ *
+ * Critically, a *bare* number (e.g. "3 action items", "2 takeaways") is treated
+ * as a quantity, NOT an ordinal. A number only counts as an ordinal when it has
+ * an ordinal suffix ("3rd"), an ordinal lead-in ("number 3", "#3", "option 3"),
+ * or an explicit list anchor ("the 3rd one", "the 3 recording"). Ordinal *words*
+ * ("third", "last") always count, but only when a referential anchor is present
+ * so unrelated phrasings like "second quarter results" are not hijacked.
+ */
+export function resolveOrdinalIndex(normalized: string, listLength: number): number | null {
+  if (listLength === 0) return null
+  const hasAnchor = REFERENTIAL_ANCHOR.test(normalized)
+
+  // "last" / "final" → end of list.
+  if (/\b(last|final|latest one|most recent one)\b/.test(normalized) && hasAnchor) {
+    return listLength - 1
+  }
+
+  // Ordinal words: first, second, ...
+  for (const [word, index] of Object.entries(ORDINAL_WORDS)) {
+    if (new RegExp(`\\b${word}\\b`).test(normalized) && hasAnchor) {
+      return index < listLength ? index : null
+    }
+  }
+
+  // Suffixed numerals: 1st, 2nd, 3rd, 4th, ...
+  const suffixed = normalized.match(/\b([0-9]{1,2})(?:st|nd|rd|th)\b/)
+  if (suffixed) {
+    const index = Number(suffixed[1]) - 1
+    return index >= 0 && index < listLength ? index : null
+  }
+
+  // Explicit positional lead-in: "number 3", "#3", "option 2".
+  const leadIn = normalized.match(/\b(?:number|option|item|#)\s*([0-9]{1,2})\b/)
+  if (leadIn) {
+    const index = Number(leadIn[1]) - 1
+    return index >= 0 && index < listLength ? index : null
+  }
+
+  // "the 3 one(s)" / "the 2 recording" — bare number directly bound to an anchor.
+  const boundNumber = normalized.match(
+    /\bthe\s+([0-9]{1,2})\s+(one|ones|recording|recordings|meeting|meetings)\b/
+  )
+  if (boundNumber) {
+    const index = Number(boundNumber[1]) - 1
+    return index >= 0 && index < listLength ? index : null
+  }
+
+  return null
+}
+
+/**
+ * Resolve a title-style reference like "the calendar auth one" to a recording,
+ * but only when a referential anchor is present and exactly one prior title is a
+ * distinct best match.
+ */
+export function resolveTitleReference(
+  normalized: string,
+  rawQuestion: string,
+  session: ChatTurnSession
+): string[] | null {
+  if (session.recordingIds.length === 0) return null
+  if (!REFERENTIAL_ANCHOR.test(normalized)) return null
+
+  const questionTerms = new Set(extractQuestionTerms(rawQuestion))
+  if (questionTerms.size === 0) return null
+
+  const scored = session.recordingTitles.map((title, index) => ({
+    id: session.recordingIds[index],
+    score: distinctiveTitleTokens(title).filter((token) => questionTerms.has(token)).length
+  }))
+
+  const best = scored.reduce((a, b) => (b.score > a.score ? b : a), { id: '', score: 0 })
+  if (best.score === 0) return null
+
+  const tiedWinners = scored.filter((entry) => entry.score === best.score)
+  if (tiedWinners.length !== 1) return null
+
+  return [best.id]
+}
+
+function distinctiveTitleTokens(title: string): string[] {
+  return normalizeRecordingSearchText(title)
+    .split(' ')
+    .filter((token) => token.length >= 3 && !GENERIC_TITLE_TOKENS.has(token))
+}
+
+// ---------------------------------------------------------------------------
+// Scoped follow-up (reuse prior scope without naming a specific item)
+// ---------------------------------------------------------------------------
+
+function resolveScopedFollowUp(normalized: string, session: ChatTurnSession): string[] {
+  if (!isImplicitFollowUp(normalized)) return []
+  if (session.focusedRecordingIds.length > 0) return session.focusedRecordingIds
+  if (session.recordingIds.length > 0) return session.recordingIds
+  return []
+}
+
+export function isImplicitFollowUp(normalized: string): boolean {
+  if (
+    /\b(anything else|what else|more|details|elaborate|what about that|that meeting|this meeting|it)\b/.test(
+      normalized
+    )
+  ) {
+    return true
+  }
+  const words = normalized.split(' ').filter(Boolean)
+  return words.length > 0 && words.length <= 8 && !hasFreshSearchTerms(normalized)
+}
+
+export function hasFreshSearchTerms(normalized: string): boolean {
+  return extractQuestionTerms(normalized).some((term) => !GENERIC_FOLLOWUP_TERMS.has(term))
+}

--- a/src/preload/ipc.d.ts
+++ b/src/preload/ipc.d.ts
@@ -128,6 +128,7 @@ export interface IpcInvokeEvents {
   'search:query': [query: string]
   'chat:send': [question: string]
   'chat:new': []
+  'chat:cancel': [requestId: string]
   'chat:send-stream': [requestId: string, question: string, history?: ChatHistoryMessage[]]
   'chat:select-recording-stream': [
     requestId: string,
@@ -237,6 +238,7 @@ export interface IpcInvokeReturns {
   'search:query': SearchResult[]
   'chat:send': string
   'chat:new': void
+  'chat:cancel': void
   'chat:send-stream': void
   'chat:select-recording-stream': void
   'detection:dismiss': void
@@ -298,6 +300,7 @@ export interface IpcOnEvents {
     }
   ]
   'chat:error': [payload: { requestId: string; error: string }]
+  'chat:canceled': [payload: { requestId: string }]
   'ollama:setup-progress': [status: OllamaSetupStatus]
   'whisper:setup-progress': [status: WhisperSetupStatus]
   'updater:status': [status: UpdateStatus]

--- a/src/renderer/src/pages/AskAI.test.tsx
+++ b/src/renderer/src/pages/AskAI.test.tsx
@@ -216,11 +216,44 @@ describe('AskAI', () => {
 
     unmount()
 
+    expect(window.electronAPI.invoke).toHaveBeenCalledWith('chat:cancel', expect.any(String))
     expect(
       useChatStore
         .getState()
         .messages.some((message) => message.role === 'assistant' && message.content.length === 0)
     ).toBe(false)
+  })
+
+  it('cancels the in-flight backend request when starting a new chat', async () => {
+    let requestId = ''
+    const api = installMockElectronApi({
+      'ollama:check-status': true,
+      'chat:new': undefined
+    })
+    api.setHandler('chat:send-stream', (id: string) => {
+      requestId = id
+      return new Promise(() => {})
+    })
+
+    render(<AskAI />)
+
+    const user = userEvent.setup()
+    await user.type(
+      screen.getByPlaceholderText(/ask a question about your meetings/i),
+      'Summarize everything'
+    )
+    await user.click(screen.getByRole('button', { name: 'Send' }))
+
+    await waitFor(() => {
+      expect(useChatStore.getState().messages.some((message) => message.status === 'pending')).toBe(
+        true
+      )
+    })
+
+    await user.click(screen.getByRole('button', { name: /new chat/i }))
+
+    expect(window.electronAPI.invoke).toHaveBeenCalledWith('chat:cancel', requestId)
+    expect(window.electronAPI.invoke).toHaveBeenCalledWith('chat:new')
   })
 
   it('times out stalled responses and ignores late stream events', async () => {

--- a/src/renderer/src/pages/AskAI.test.tsx
+++ b/src/renderer/src/pages/AskAI.test.tsx
@@ -110,6 +110,68 @@ describe('AskAI', () => {
     })
   })
 
+  it('stops an in-flight response, cancels the backend, and keeps partial text', async () => {
+    let requestId = ''
+    const api = installMockElectronApi({
+      'ollama:check-status': true
+    })
+    api.setHandler('chat:send-stream', (id: string) => {
+      requestId = id
+      queueMicrotask(() => {
+        api.emit('chat:chunk', { requestId: id, content: 'Partial answer' })
+      })
+      return new Promise(() => {})
+    })
+
+    render(<AskAI />)
+
+    const user = userEvent.setup()
+    await user.type(
+      screen.getByPlaceholderText(/ask a question about your meetings/i),
+      'Summarize everything'
+    )
+    await user.click(screen.getByRole('button', { name: 'Send' }))
+
+    expect(await screen.findByText('Partial answer')).toBeInTheDocument()
+
+    await user.click(await screen.findByRole('button', { name: /stop generating/i }))
+
+    expect(window.electronAPI.invoke).toHaveBeenCalledWith('chat:cancel', requestId)
+    expect(screen.getByRole('button', { name: 'Send' })).toBeInTheDocument()
+
+    const assistantMessage = useChatStore
+      .getState()
+      .messages.find((message) => message.role === 'assistant')
+    expect(assistantMessage?.status).toBe('canceled')
+    expect(assistantMessage?.content).toBe('Partial answer')
+  })
+
+  it('removes the empty bubble when stopping before any token arrives', async () => {
+    const api = installMockElectronApi({
+      'ollama:check-status': true
+    })
+    api.setHandler('chat:send-stream', () => new Promise(() => {}))
+
+    render(<AskAI />)
+
+    const user = userEvent.setup()
+    await user.type(
+      screen.getByPlaceholderText(/ask a question about your meetings/i),
+      'Summarize everything'
+    )
+    await user.click(screen.getByRole('button', { name: 'Send' }))
+
+    await user.click(await screen.findByRole('button', { name: /stop generating/i }))
+
+    expect(window.electronAPI.invoke).toHaveBeenCalledWith('chat:cancel', expect.any(String))
+    expect(
+      useChatStore
+        .getState()
+        .messages.some((message) => message.role === 'assistant' && message.content.length === 0)
+    ).toBe(false)
+    expect(screen.getByRole('button', { name: 'Send' })).toBeInTheDocument()
+  })
+
   it('persists the draft when the Ask AI view remounts', async () => {
     installMockElectronApi({
       'ollama:check-status': true

--- a/src/renderer/src/pages/AskAI.test.tsx
+++ b/src/renderer/src/pages/AskAI.test.tsx
@@ -1,8 +1,9 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { AskAI } from './AskAI'
 import { installMockElectronApi, resetRendererStores } from '../test/fixtures'
+import { useChatStore } from '../stores/chat'
 
 describe('AskAI', () => {
   beforeEach(() => {
@@ -11,6 +12,10 @@ describe('AskAI', () => {
       configurable: true,
       value: vi.fn()
     })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   it('shows the reconnecting hint when Ollama is not ready yet', async () => {
@@ -103,6 +108,91 @@ describe('AskAI', () => {
     await waitFor(() => {
       expect(screen.getByText(/make sure Ollama is running and try again/i)).toBeInTheDocument()
     })
+  })
+
+  it('persists the draft when the Ask AI view remounts', async () => {
+    installMockElectronApi({
+      'ollama:check-status': true
+    })
+
+    const { unmount } = render(<AskAI />)
+    await act(async () => {})
+    const user = userEvent.setup()
+    await user.type(
+      screen.getByPlaceholderText(/ask a question about your meetings/i),
+      'Draft about the second recording'
+    )
+
+    unmount()
+    render(<AskAI />)
+    await act(async () => {})
+
+    expect(screen.getByPlaceholderText(/ask a question about your meetings/i)).toHaveValue(
+      'Draft about the second recording'
+    )
+  })
+
+  it('removes an empty pending assistant message when the view unmounts', async () => {
+    const api = installMockElectronApi({
+      'ollama:check-status': true
+    })
+    api.setHandler('chat:send-stream', () => new Promise(() => {}))
+
+    const { unmount } = render(<AskAI />)
+    const user = userEvent.setup()
+    await user.type(
+      screen.getByPlaceholderText(/ask a question about your meetings/i),
+      'Who owns billing migration?'
+    )
+    await user.click(screen.getByRole('button', { name: 'Send' }))
+
+    await waitFor(() => {
+      expect(useChatStore.getState().messages.some((message) => message.status === 'pending')).toBe(
+        true
+      )
+    })
+
+    unmount()
+
+    expect(
+      useChatStore
+        .getState()
+        .messages.some((message) => message.role === 'assistant' && message.content.length === 0)
+    ).toBe(false)
+  })
+
+  it('times out stalled responses and ignores late stream events', async () => {
+    vi.useFakeTimers()
+    let requestId = ''
+    const api = installMockElectronApi({
+      'ollama:check-status': true
+    })
+    api.setHandler('chat:send-stream', (id: string) => {
+      requestId = id
+      return new Promise(() => {})
+    })
+
+    render(<AskAI />)
+
+    const input = screen.getByPlaceholderText(/ask a question about your meetings/i)
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'Summarize the second recording' } })
+      fireEvent.keyDown(input, { key: 'Enter' })
+    })
+
+    expect(requestId).not.toBe('')
+
+    act(() => {
+      vi.advanceTimersByTime(45_000)
+    })
+
+    expect(screen.getByText(/taking longer than expected/i)).toBeInTheDocument()
+
+    act(() => {
+      api.emit('chat:done', { requestId, content: 'Late answer that should be ignored' })
+    })
+
+    expect(screen.queryByText('Late answer that should be ignored')).not.toBeInTheDocument()
   })
 
   it('renders clarification options as selectable meetings and sends the meeting id', async () => {

--- a/src/renderer/src/pages/AskAI.tsx
+++ b/src/renderer/src/pages/AskAI.tsx
@@ -46,6 +46,10 @@ export function AskAI(): ReactElement {
 
   useEffect(() => {
     return () => {
+      const activeRequestId = activeRequestIdRef.current
+      if (activeRequestId) {
+        void window.electronAPI.invoke('chat:cancel', activeRequestId)
+      }
       activeStreamCleanupRef.current?.()
       clearRequestTimeouts()
       const activeAssistantMessageId = activeAssistantMessageIdRef.current
@@ -244,6 +248,10 @@ export function AskAI(): ReactElement {
   }
 
   const handleNewChat = async (): Promise<void> => {
+    const activeRequestId = activeRequestIdRef.current
+    if (activeRequestId) {
+      void window.electronAPI.invoke('chat:cancel', activeRequestId)
+    }
     activeStreamCleanupRef.current?.()
     activeStreamCleanupRef.current = null
     clearRequestTimeouts()

--- a/src/renderer/src/pages/AskAI.tsx
+++ b/src/renderer/src/pages/AskAI.tsx
@@ -6,6 +6,8 @@ import { recordDiagnosticAction } from '../services/diagnostic-trail'
 import type { ChatClarificationOption } from '../../../preload/ipc'
 
 let fallbackRequestIdCounter = 0
+const FIRST_TOKEN_TIMEOUT_MS = 45_000
+const COMPLETION_TIMEOUT_MS = 180_000
 
 function createChatRequestId(): string {
   const randomId = globalThis.crypto?.randomUUID?.()
@@ -16,13 +18,26 @@ function createChatRequestId(): string {
 }
 
 export function AskAI(): ReactElement {
-  const { messages, addMessage, updateMessage, appendToMessage, clearMessages } = useChatStore()
-  const [input, setInput] = useState('')
+  const {
+    messages,
+    draftInput,
+    addMessage,
+    updateMessage,
+    appendToMessage,
+    setMessageStatus,
+    removeEmptyInFlightAssistantMessages,
+    setDraftInput,
+    clearMessages
+  } = useChatStore()
   const [loading, setLoading] = useState(false)
   const [ollamaReady, setOllamaReady] = useState<boolean | null>(null)
   const scrollRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
   const activeStreamCleanupRef = useRef<(() => void) | null>(null)
+  const activeRequestIdRef = useRef<string | null>(null)
+  const activeAssistantMessageIdRef = useRef<string | null>(null)
+  const firstTokenTimeoutRef = useRef<number | null>(null)
+  const completionTimeoutRef = useRef<number | null>(null)
   const isSendingRef = useRef(false)
 
   useEffect(() => {
@@ -32,12 +47,54 @@ export function AskAI(): ReactElement {
   useEffect(() => {
     return () => {
       activeStreamCleanupRef.current?.()
+      clearRequestTimeouts()
+      const activeAssistantMessageId = activeAssistantMessageIdRef.current
+      if (activeAssistantMessageId) {
+        setMessageStatus(activeAssistantMessageId, 'canceled')
+      }
+      removeEmptyInFlightAssistantMessages()
+      activeRequestIdRef.current = null
+      activeAssistantMessageIdRef.current = null
+      isSendingRef.current = false
     }
-  }, [])
+  }, [removeEmptyInFlightAssistantMessages, setMessageStatus])
 
   useEffect(() => {
     scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: 'smooth' })
   }, [messages, loading])
+
+  const clearRequestTimeouts = (): void => {
+    if (firstTokenTimeoutRef.current) {
+      window.clearTimeout(firstTokenTimeoutRef.current)
+      firstTokenTimeoutRef.current = null
+    }
+    if (completionTimeoutRef.current) {
+      window.clearTimeout(completionTimeoutRef.current)
+      completionTimeoutRef.current = null
+    }
+  }
+
+  const finishActiveRequest = (): void => {
+    clearRequestTimeouts()
+    isSendingRef.current = false
+    setLoading(false)
+    activeRequestIdRef.current = null
+    activeAssistantMessageIdRef.current = null
+    activeStreamCleanupRef.current?.()
+    activeStreamCleanupRef.current = null
+    inputRef.current?.focus()
+  }
+
+  const markActiveRequestTimedOut = (requestId: string, messageId: string): void => {
+    if (activeRequestIdRef.current !== requestId) return
+    updateMessage(
+      messageId,
+      'Sorry, this is taking longer than expected. Please try again.',
+      undefined,
+      'timed_out'
+    )
+    finishActiveRequest()
+  }
 
   const sendChatRequest = async (params: {
     question: string
@@ -45,13 +102,16 @@ export function AskAI(): ReactElement {
     selectedMeetingId?: string
   }): Promise<void> => {
     const question = params.question.trim()
-    if (!question || loading || isSendingRef.current) return
+    if (!question || loading || isSendingRef.current || activeRequestIdRef.current) return
     isSendingRef.current = true
     activeStreamCleanupRef.current?.()
+    clearRequestTimeouts()
     const requestId = createChatRequestId()
     const assistantMessageId = `assistant-${requestId}`
+    activeRequestIdRef.current = requestId
+    activeAssistantMessageIdRef.current = assistantMessageId
     const history = messages
-      .filter((message) => message.content.trim().length > 0)
+      .filter((message) => message.content.trim().length > 0 && message.status !== 'timed_out')
       .slice(-8)
       .map((message) => ({ role: message.role, content: message.content }))
     addMessage({ role: 'user', content: params.displayQuestion })
@@ -59,6 +119,7 @@ export function AskAI(): ReactElement {
       id: assistantMessageId,
       role: 'assistant',
       content: '',
+      status: 'pending',
       originalQuestion: question
     })
     setLoading(true)
@@ -74,34 +135,43 @@ export function AskAI(): ReactElement {
     const cleanupListeners = [
       window.electronAPI.on('chat:chunk', (payload) => {
         if (payload.requestId !== requestId) return
+        if (activeRequestIdRef.current !== requestId) return
+        if (firstTokenTimeoutRef.current) {
+          window.clearTimeout(firstTokenTimeoutRef.current)
+          firstTokenTimeoutRef.current = null
+        }
         appendToMessage(assistantMessageId, payload.content)
       }),
       window.electronAPI.on('chat:done', (payload) => {
         if (payload.requestId !== requestId) return
-        updateMessage(assistantMessageId, payload.content, payload.clarificationOptions)
-        isSendingRef.current = false
-        setLoading(false)
-        activeStreamCleanupRef.current?.()
-        activeStreamCleanupRef.current = null
-        inputRef.current?.focus()
+        if (activeRequestIdRef.current !== requestId) return
+        updateMessage(assistantMessageId, payload.content, payload.clarificationOptions, 'complete')
+        finishActiveRequest()
       }),
       window.electronAPI.on('chat:error', (payload) => {
         if (payload.requestId !== requestId) return
+        if (activeRequestIdRef.current !== requestId) return
         updateMessage(
           assistantMessageId,
-          'Sorry, I had trouble answering that. Make sure Ollama is running and try again.'
+          'Sorry, I had trouble answering that. Make sure Ollama is running and try again.',
+          undefined,
+          'failed'
         )
         console.error('Chat failed:', payload.error)
-        isSendingRef.current = false
-        setLoading(false)
-        activeStreamCleanupRef.current?.()
-        activeStreamCleanupRef.current = null
-        inputRef.current?.focus()
+        finishActiveRequest()
       })
     ]
     activeStreamCleanupRef.current = () => {
       for (const cleanup of cleanupListeners) cleanup()
     }
+    firstTokenTimeoutRef.current = window.setTimeout(
+      () => markActiveRequestTimedOut(requestId, assistantMessageId),
+      FIRST_TOKEN_TIMEOUT_MS
+    )
+    completionTimeoutRef.current = window.setTimeout(
+      () => markActiveRequestTimedOut(requestId, assistantMessageId),
+      COMPLETION_TIMEOUT_MS
+    )
 
     try {
       if (params.selectedMeetingId) {
@@ -116,23 +186,22 @@ export function AskAI(): ReactElement {
         await window.electronAPI.invoke('chat:send-stream', requestId, question, history)
       }
     } catch (err) {
+      if (activeRequestIdRef.current !== requestId) return
       updateMessage(
         assistantMessageId,
-        'Sorry, I had trouble answering that. Make sure Ollama is running and try again.'
+        'Sorry, I had trouble answering that. Make sure Ollama is running and try again.',
+        undefined,
+        'failed'
       )
       console.error('Chat failed:', err)
-      isSendingRef.current = false
-      setLoading(false)
-      activeStreamCleanupRef.current?.()
-      activeStreamCleanupRef.current = null
-      inputRef.current?.focus()
+      finishActiveRequest()
     }
   }
 
   const handleSend = async (): Promise<void> => {
-    const question = input.trim()
+    const question = draftInput.trim()
     if (!question || loading) return
-    setInput('')
+    setDraftInput('')
     await sendChatRequest({ question, displayQuestion: question })
   }
 
@@ -158,9 +227,11 @@ export function AskAI(): ReactElement {
   const handleNewChat = async (): Promise<void> => {
     activeStreamCleanupRef.current?.()
     activeStreamCleanupRef.current = null
+    clearRequestTimeouts()
     isSendingRef.current = false
+    activeRequestIdRef.current = null
+    activeAssistantMessageIdRef.current = null
     clearMessages()
-    setInput('')
     setLoading(false)
     await window.electronAPI.invoke('chat:new')
     inputRef.current?.focus()
@@ -174,7 +245,7 @@ export function AskAI(): ReactElement {
           <button
             type="button"
             onClick={handleNewChat}
-            disabled={messages.length === 0 && !input.trim()}
+            disabled={messages.length === 0 && !draftInput.trim()}
             className="px-3 py-1.5 rounded-lg border border-border bg-bg-card text-[12px] font-medium text-ink hover:border-sage hover:bg-sage/5 transition-colors disabled:opacity-40"
           >
             New chat
@@ -226,7 +297,9 @@ export function AskAI(): ReactElement {
                       : 'bg-bg-card border border-border text-ink rounded-bl-md'
                   }`}
                 >
-                  {msg.role === 'assistant' && msg.content.length === 0 ? (
+                  {msg.role === 'assistant' &&
+                  msg.content.length === 0 &&
+                  (msg.status === 'pending' || msg.status === 'streaming') ? (
                     <div className="flex gap-1.5 py-1">
                       <span
                         className="w-2 h-2 rounded-full bg-ink-faint animate-bounce"
@@ -285,8 +358,8 @@ export function AskAI(): ReactElement {
           <input
             ref={inputRef}
             type="text"
-            value={input}
-            onChange={(e) => setInput(e.target.value)}
+            value={draftInput}
+            onChange={(e) => setDraftInput(e.target.value)}
             onKeyDown={handleKeyDown}
             placeholder="Ask a question about your meetings..."
             disabled={loading}
@@ -295,7 +368,7 @@ export function AskAI(): ReactElement {
           />
           <button
             onClick={handleSend}
-            disabled={!input.trim() || loading}
+            disabled={!draftInput.trim() || loading}
             className="px-4 py-2.5 bg-sage text-white rounded-lg text-[13px] font-medium hover:opacity-90 transition-opacity disabled:opacity-40"
           >
             Send

--- a/src/renderer/src/pages/AskAI.tsx
+++ b/src/renderer/src/pages/AskAI.tsx
@@ -159,6 +159,13 @@ export function AskAI(): ReactElement {
         )
         console.error('Chat failed:', payload.error)
         finishActiveRequest()
+      }),
+      window.electronAPI.on('chat:canceled', (payload) => {
+        if (payload.requestId !== requestId) return
+        if (activeRequestIdRef.current !== requestId) return
+        setMessageStatus(assistantMessageId, 'canceled')
+        removeEmptyInFlightAssistantMessages()
+        finishActiveRequest()
       })
     ]
     activeStreamCleanupRef.current = () => {
@@ -203,6 +210,18 @@ export function AskAI(): ReactElement {
     if (!question || loading) return
     setDraftInput('')
     await sendChatRequest({ question, displayQuestion: question })
+  }
+
+  const handleStop = (): void => {
+    const requestId = activeRequestIdRef.current
+    const assistantMessageId = activeAssistantMessageIdRef.current
+    if (!requestId) return
+    void window.electronAPI.invoke('chat:cancel', requestId)
+    if (assistantMessageId) {
+      setMessageStatus(assistantMessageId, 'canceled')
+    }
+    removeEmptyInFlightAssistantMessages()
+    finishActiveRequest()
   }
 
   const handleClarificationSelect = async (
@@ -366,13 +385,26 @@ export function AskAI(): ReactElement {
             className="flex-1 px-4 py-2.5 bg-bg-card border border-border rounded-lg text-[13px] text-ink placeholder:text-ink-faint focus:outline-none focus:border-sage transition-colors disabled:opacity-50"
             autoFocus
           />
-          <button
-            onClick={handleSend}
-            disabled={!draftInput.trim() || loading}
-            className="px-4 py-2.5 bg-sage text-white rounded-lg text-[13px] font-medium hover:opacity-90 transition-opacity disabled:opacity-40"
-          >
-            Send
-          </button>
+          {loading ? (
+            <button
+              type="button"
+              onClick={handleStop}
+              aria-label="Stop generating"
+              className="px-4 py-2.5 bg-clay text-white rounded-lg text-[13px] font-medium hover:opacity-90 transition-opacity flex items-center gap-1.5"
+            >
+              <span className="w-2.5 h-2.5 rounded-[2px] bg-white" />
+              Stop
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={handleSend}
+              disabled={!draftInput.trim()}
+              className="px-4 py-2.5 bg-sage text-white rounded-lg text-[13px] font-medium hover:opacity-90 transition-opacity disabled:opacity-40"
+            >
+              Send
+            </button>
+          )}
         </div>
       </div>
     </div>

--- a/src/renderer/src/stores/chat.ts
+++ b/src/renderer/src/stores/chat.ts
@@ -6,19 +6,25 @@ export interface Message {
   id?: string
   role: 'user' | 'assistant'
   content: string
+  status?: 'pending' | 'streaming' | 'complete' | 'failed' | 'canceled' | 'timed_out'
   originalQuestion?: string
   clarificationOptions?: ChatClarificationOption[]
 }
 
 interface ChatState {
   messages: Message[]
+  draftInput: string
   addMessage: (msg: Message) => void
   updateMessage: (
     id: string,
     content: string,
-    clarificationOptions?: ChatClarificationOption[]
+    clarificationOptions?: ChatClarificationOption[],
+    status?: Message['status']
   ) => void
   appendToMessage: (id: string, chunk: string) => void
+  setMessageStatus: (id: string, status: Message['status']) => void
+  removeEmptyInFlightAssistantMessages: () => void
+  setDraftInput: (value: string) => void
   clearMessages: () => void
 }
 
@@ -29,8 +35,9 @@ export const useChatStore = create<ChatState>()(
   persist(
     (set) => ({
       messages: [],
+      draftInput: '',
       addMessage: (msg) => set((state) => ({ messages: capMessages([...state.messages, msg]) })),
-      updateMessage: (id, content, clarificationOptions) =>
+      updateMessage: (id, content, clarificationOptions, status) =>
         set((state) => ({
           messages: capMessages(
             state.messages.map((msg) =>
@@ -38,7 +45,8 @@ export const useChatStore = create<ChatState>()(
                 ? {
                     ...msg,
                     content,
-                    clarificationOptions: clarificationOptions ?? msg.clarificationOptions
+                    clarificationOptions: clarificationOptions ?? msg.clarificationOptions,
+                    status: status ?? msg.status
                   }
                 : msg
             )
@@ -48,15 +56,40 @@ export const useChatStore = create<ChatState>()(
         set((state) => ({
           messages: capMessages(
             state.messages.map((msg) =>
-              msg.id === id ? { ...msg, content: msg.content + chunk } : msg
+              msg.id === id ? { ...msg, content: msg.content + chunk, status: 'streaming' } : msg
             )
           )
         })),
-      clearMessages: () => set({ messages: [] })
+      setMessageStatus: (id, status) =>
+        set((state) => ({
+          messages: capMessages(
+            state.messages.map((msg) => (msg.id === id ? { ...msg, status } : msg))
+          )
+        })),
+      removeEmptyInFlightAssistantMessages: () =>
+        set((state) => ({
+          messages: state.messages.filter(
+            (msg) =>
+              !(
+                msg.role === 'assistant' &&
+                msg.content.trim().length === 0 &&
+                (msg.status === 'pending' ||
+                  msg.status === 'streaming' ||
+                  msg.status === 'canceled')
+              )
+          )
+        })),
+      setDraftInput: (value) => set({ draftInput: value }),
+      clearMessages: () => set({ messages: [], draftInput: '' })
     }),
     {
       name: 'autodoc-ask-ai-chat',
-      partialize: (state) => ({ messages: state.messages.slice(-MAX_CHAT_MESSAGES) })
+      partialize: (state) => ({
+        messages: state.messages
+          .filter((message) => message.status !== 'pending' && message.status !== 'streaming')
+          .slice(-MAX_CHAT_MESSAGES),
+        draftInput: state.draftInput
+      })
     }
   )
 )

--- a/src/renderer/src/test/fixtures.ts
+++ b/src/renderer/src/test/fixtures.ts
@@ -81,7 +81,7 @@ export function resetRendererStores(): void {
     events: [],
     isSyncing: false
   })
-  useChatStore.setState({ messages: [] })
+  useChatStore.setState({ messages: [], draftInput: '' })
   useSearchStore.setState({ query: '', results: [], searched: false })
   useToastStore.setState({ activeToast: null })
   useRecordingStore.setState({


### PR DESCRIPTION
## Summary

- Fixes Ask AI follow-up failures (AD-83): acknowledgements, count confirmations, ordinal/title coreference, and scoped follow-ups no longer fall through to full retrieval/model, which caused wrong recordings, contradictory counts, and hung empty bubbles.
- Replaces scattered routing heuristics with a unified `chat-turn-classifier`, wires it through `chat-ipc`, and adds a deterministic routing benchmark (25 scenarios, 100% pass vs 13/21 baseline).
- Adds instant small-talk replies for greetings/capability questions, a hard-cancel **Stop** button (`chat:cancel` aborts Ollama), and renderer lifecycle hardening (message statuses, timeouts, draft persistence, stale stream cleanup).
- Disables Windows CI builds temporarily so the pipeline ships **macOS-only** (`build-win` skipped; release publish is mac-only).

## Test plan

- [ ] `npm run test:main:run -- src/main/ipc/__tests__/chat-ipc.test.ts src/main/ipc/__tests__/ask-ai-routing.benchmark.test.ts src/main/services/__tests__/chat-turn-classifier.test.ts src/main/services/__tests__/chat-retrieval.test.ts`
- [ ] `npm run test:run -- src/renderer/src/pages/AskAI.test.tsx`
- [ ] `npm run typecheck`
- [ ] Manual: list recordings → `second one` / `2nd` selects correct meeting; `thanks` / `ok cool` instant; count confirm (`so four then?`) deterministic; `hey` instant greeting; **Stop** mid-stream aborts and preserves partial text
- [ ] CI: confirm `build-mac` runs and `build-win` is skipped on push