### PR TITLE
Clean up macOS build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,9 +3,6 @@ name: Build & Release
 on:
   push:
     branches:
-      # Add a developer branch here when you want test artifacts from CI.
-      - codex/single-instance-installed-copy
-      - bugFixes0.1.27
       - main
     tags:
       - 'v*'
@@ -68,12 +65,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Install macOS Whisper runtime build packages
-        run: |
-          brew list whisper-cpp >/dev/null 2>&1 || brew install whisper-cpp
-          brew list ggml >/dev/null 2>&1 || brew install ggml
-          brew list libomp >/dev/null 2>&1 || brew install libomp
-
       - name: Run bootstrap tests
         run: npm run test:main:run -- src/main/services/__tests__/whisper-manager.test.ts
 
@@ -107,19 +98,8 @@ jobs:
           npm run build
           npx electron-builder --mac --publish never "-c.extraMetadata.version=${{ steps.release_meta.outputs.release_version }}"
 
-      - name: Build macOS test release v0.1.27-beta.2 (signed + notarized)
-        if: github.event_name == 'push' && github.ref_name == 'bugFixes0.1.27'
-        env:
-          APPLE_ID: ${{ secrets.DD_APPLE_ID }}
-          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.DD_APPLE_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.DD_APPLE_TEAM }}
-        run: |
-          npm run prepare:macos-mlx-runtime
-          npm run build
-          npx electron-builder --mac --publish never "-c.extraMetadata.version=0.1.27-beta.2"
-
       - name: Build macOS artifacts (signed, no notarization)
-        if: github.event_name == 'push' && github.ref_type == 'branch' && github.ref_name != 'bugFixes0.1.27'
+        if: github.event_name == 'push' && github.ref_type == 'branch'
         run: npm run prepare:macos-mlx-runtime && npm run build && npx electron-builder --mac --publish never --config.mac.notarize=false
 
       - name: Upload macOS artifacts


### PR DESCRIPTION
## Summary

Removes stale macOS build workflow paths that were left over from the older whisper-cpp packaging flow and the temporary v0.1.27-beta.2 branch release path.

## What changed

- Removed the explicit codex/single-instance-installed-copy and bugFixes0.1.27 push triggers so the release workflow only runs on main, v* tags, and manual dispatch.
- Removed the Homebrew install step for whisper-cpp, ggml, and libomp; the active macOS package path uses prepare:macos-mlx-runtime instead of the old prepare:macos-whisper-runtime script.
- Removed the hard-coded Build macOS test release v0.1.27-beta.2 step.
- Simplified the normal branch artifact build condition now that there is no special bugFixes0.1.27 exclusion.

## Validation

- npm run test:main:run -- src/main/services/__tests__/whisper-manager.test.ts
- npm run prepare:macos-mlx-runtime
- npm run build
- npx electron-builder --mac --publish never --config.mac.notarize=false

Note: the first packaging attempt hit the local sandbox when Electron Builder tried to write ~/Library/Caches/electron-builder; rerunning the packaging step outside the sandbox completed successfully and produced the macOS zip, DMG, blockmap, and latest-mac.yml.