### PR TITLE
Fix macOS transcription runtime SIGKILL (missing JIT entitlements)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,7 +110,7 @@ jobs:
           }}
         run: npm run prepare:macos-mlx-runtime && npm run build && npx electron-builder --mac --publish never --config.mac.notarize=false
 
-      - name: Verify macOS update artifact integrity
+      - name: Verify macOS artifacts (signature, entitlements, runtime)
         run: bash scripts/verify-macos-update-artifact.sh dist
 
       - name: Upload macOS artifacts

--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -8,5 +8,7 @@
     <true/>
     <key>com.apple.security.cs.allow-dyld-environment-variables</key>
     <true/>
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
   </dict>
 </plist>

--- a/scripts/after-pack-mac-privacy.cjs
+++ b/scripts/after-pack-mac-privacy.cjs
@@ -1,6 +1,6 @@
 const { readdir, rm, stat } = require('fs/promises')
 const { existsSync } = require('fs')
-const { join } = require('path')
+const { isAbsolute, join } = require('path')
 const { execFileSync } = require('child_process')
 
 const PRIVACY_STRINGS = {
@@ -59,6 +59,28 @@ function tryGetSigningIdentity(context) {
     findSigningIdentity((entry) => entry.includes('Developer ID Application:')) ??
     findSigningIdentity((entry) => entry.includes('Apple Development:'))
   )
+}
+
+// The bundled MLX/Python runtime allocates executable (JIT) memory at import
+// time. Because `mac.signIgnore` excludes Contents/Resources, electron-builder's
+// signer never applies the inherited entitlements to these binaries, so we must
+// sign them here with the same Hardened Runtime entitlements the main app uses
+// (allow-jit / allow-unsigned-executable-memory). Without them macOS SIGKILLs
+// the runtime with "Code Signature Invalid" the moment transcription starts.
+function resolveResourceEntitlementsPath(context) {
+  const configured =
+    context?.packager?.platformSpecificBuildOptions?.entitlements ??
+    context?.packager?.config?.mac?.entitlements ??
+    context?.packager?.platformSpecificBuildOptions?.entitlementsInherit ??
+    context?.packager?.config?.mac?.entitlementsInherit
+
+  const candidates = []
+  if (configured) {
+    candidates.push(isAbsolute(configured) ? configured : join(process.cwd(), configured))
+  }
+  candidates.push(join(__dirname, '..', 'build', 'entitlements.mac.plist'))
+
+  return candidates.find((candidate) => existsSync(candidate)) ?? null
 }
 
 async function walk(dirPath) {
@@ -130,6 +152,13 @@ async function signMachOBinariesUnder(runtimeRoot, label, context) {
     return 0
   }
 
+  const entitlementsPath = resolveResourceEntitlementsPath(context)
+  if (!entitlementsPath) {
+    console.warn(
+      `[afterPack] WARNING: no entitlements file found for ${label}; the bundled runtime may be SIGKILLed at runtime (missing allow-jit).`
+    )
+  }
+
   const files = await walk(runtimeRoot)
   const binaries = []
 
@@ -146,10 +175,17 @@ async function signMachOBinariesUnder(runtimeRoot, label, context) {
   binaries.sort((left, right) => right.split('/').length - left.split('/').length)
 
   for (const binaryPath of binaries) {
-    execFileSync(
-      'codesign',
-      ['--force', '--sign', identity, '--timestamp', '--options', 'runtime', binaryPath],
-      { stdio: 'inherit' }
+    const codesignArgs = ['--force', '--sign', identity, '--timestamp', '--options', 'runtime']
+    if (entitlementsPath) {
+      codesignArgs.push('--entitlements', entitlementsPath)
+    }
+    codesignArgs.push(binaryPath)
+    execFileSync('codesign', codesignArgs, { stdio: 'inherit' })
+  }
+
+  if (binaries.length > 0 && entitlementsPath) {
+    console.log(
+      `[afterPack] Applied Hardened Runtime entitlements (${entitlementsPath}) to ${binaries.length} ${label}`
     )
   }
 

--- a/scripts/verify-macos-update-artifact.sh
+++ b/scripts/verify-macos-update-artifact.sh
@@ -93,18 +93,28 @@ verify_app_entitlements() {
   if grep -qi 'invalid entitlements blob' <<<"$output"; then
     die "Extracted app has an invalid entitlements blob; ensure mac.entitlements points to ${MAC_ENTITLEMENTS_FILE}."
   fi
-  if grep -q 'com.apple.security.device.audio-input' <<<"$output"; then
-    die "Extracted app has com.apple.security.device.audio-input; ensure mac.entitlements points to ${MAC_ENTITLEMENTS_FILE}."
+  # The microphone is gated by the Hardened Runtime audio-input entitlement.
+  # Without it macOS auto-denies askForMediaAccess (no prompt) and AutoDoc never
+  # appears in Privacy > Microphone, so recordings capture no audio. Screen
+  # recording uses a different TCC path and is unaffected, which makes this easy
+  # to miss. Fail the build if it is ever dropped again.
+  if ! grep -q 'com.apple.security.device.audio-input' <<<"$output"; then
+    die "App is missing com.apple.security.device.audio-input; microphone access will be denied at runtime. Restore it in ${MAC_ENTITLEMENTS_FILE}."
   fi
 }
 
 verify_entitlement_config() {
   [[ -f "$MAC_ENTITLEMENTS_FILE" ]] || return 0
 
-  if /usr/libexec/PlistBuddy \
+  # com.apple.security.device.audio-input is the Hardened Runtime entitlement
+  # that authorizes microphone access for our Developer ID app. It is valid for
+  # notarized Developer ID builds (shipped in v0.1.21–v0.1.46 with working mics).
+  # It was removed in error chasing a misdiagnosed "invalid signature" report,
+  # which silently broke microphone capture. Require it so it cannot regress.
+  if ! /usr/libexec/PlistBuddy \
     -c 'Print :com.apple.security.device.audio-input' \
     "$MAC_ENTITLEMENTS_FILE" >/dev/null 2>&1; then
-    die "Remove com.apple.security.device.audio-input from ${MAC_ENTITLEMENTS_FILE}; it is an App Sandbox entitlement and makes Developer ID signatures invalid on newer macOS versions."
+    die "${MAC_ENTITLEMENTS_FILE} is missing com.apple.security.device.audio-input; microphone access will be denied at runtime. Restore it."
   fi
 }
 

--- a/scripts/verify-macos-update-artifact.sh
+++ b/scripts/verify-macos-update-artifact.sh
@@ -1,11 +1,17 @@
 #!/usr/bin/env bash
-# Verifies that the macOS update zip extracts to a code-sign-valid app bundle.
+# Verifies macOS release artifacts:
+#   * the update zip extracts to a code-sign-valid app bundle (auto-update path)
+#   * the DMG mounts to a code-sign-valid app bundle (manual install path)
+#   * the bundled MLX/Python runtime carries the JIT entitlements and can be
+#     imported without a Hardened Runtime SIGKILL (transcription setup path)
 
 set -euo pipefail
 
 ARTIFACT_DIR="${1:-dist}"
 APP_NAME="${AUTODOC_MAC_APP_NAME:-AutoDoc.app}"
 MAC_ENTITLEMENTS_FILE="${AUTODOC_MAC_ENTITLEMENTS_FILE:-build/entitlements.mac.plist}"
+# Set to 0 to skip the runtime import probe (e.g. on hosts without the runtime).
+RUNTIME_PROBE="${AUTODOC_MAC_RUNTIME_PROBE:-1}"
 
 die() {
   echo "FATAL: $*" >&2
@@ -27,10 +33,56 @@ find_update_zip() {
   find "$ARTIFACT_DIR" -maxdepth 1 -name '*-mac.zip' -type f | sort | head -1
 }
 
+find_dmg() {
+  find "$ARTIFACT_DIR" -maxdepth 1 -name '*.dmg' -type f | sort | head -1
+}
+
 verify_app_signature() {
   local app_path="$1"
   [[ -d "$app_path" ]] || die "Missing app bundle: ${app_path}"
   codesign --verify --deep --strict --verbose=4 "$app_path"
+}
+
+# Confirms the bundled MLX/Python runtime is signed with the JIT entitlements and
+# survives an actual import. This is the only check that catches the Hardened
+# Runtime "Code Signature Invalid" SIGKILL that breaks transcription setup —
+# codesign --verify reports the signature as valid even when allow-jit is absent.
+verify_app_runtime() {
+  local app_path="$1"
+
+  if [[ "$RUNTIME_PROBE" != "1" ]]; then
+    echo "[verify-macos-update] Runtime probe disabled (AUTODOC_MAC_RUNTIME_PROBE=${RUNTIME_PROBE})"
+    return 0
+  fi
+
+  local runtime_root
+  runtime_root="$(/bin/ls -d "${app_path}/Contents/Resources/mlx-python-runtime/"*/ 2>/dev/null | head -1 || true)"
+  [[ -n "$runtime_root" ]] || die "Bundled MLX runtime missing under ${app_path}/Contents/Resources/mlx-python-runtime"
+
+  local python_bin="${runtime_root}python/bin/python3"
+  [[ -e "$python_bin" ]] || die "Bundled MLX runtime python missing: ${python_bin}"
+
+  local entitlements
+  entitlements="$(codesign -d --entitlements - "$python_bin" 2>/dev/null || true)"
+  if ! grep -q 'com.apple.security.cs.allow-jit' <<<"$entitlements"; then
+    die "Bundled python3 is missing com.apple.security.cs.allow-jit; MLX will be SIGKILLed (Code Signature Invalid) at runtime. Fix afterPack runtime signing."
+  fi
+
+  set +e
+  local probe_output
+  probe_output="$(PYTHONDONTWRITEBYTECODE=1 "$python_bin" -c 'import mlx_whisper; print("mlx_whisper import OK")' 2>&1)"
+  local probe_rc=$?
+  set -e
+
+  if [[ "$probe_rc" != "0" ]]; then
+    echo "$probe_output" >&2
+    if [[ "$probe_rc" == "137" ]]; then
+      die "Bundled MLX runtime was SIGKILLed (137) importing mlx_whisper — Hardened Runtime rejected JIT memory because the bundled python is missing allow-jit/allow-unsigned-executable-memory entitlements."
+    fi
+    die "Bundled MLX runtime failed to import mlx_whisper (exit ${probe_rc})."
+  fi
+
+  echo "[verify-macos-update] Runtime import probe OK (${python_bin})"
 }
 
 verify_app_entitlements() {
@@ -74,9 +126,41 @@ ditto -x -k "$zip_path" "$tmp_dir"
 extracted_app="${tmp_dir}/${APP_NAME}"
 verify_app_entitlements "$extracted_app"
 verify_app_signature "$extracted_app"
+verify_app_runtime "$extracted_app"
 
 detached_signature_count="$(
   xattr -lr "$extracted_app" 2>/dev/null | grep -c 'com.apple.cs.CodeSignature' || true
 )"
 echo "[verify-macos-update] Extracted app detached signature xattrs: ${detached_signature_count}"
+echo "[verify-macos-update] Update zip OK"
+
+# Verify the DMG (the artifact users actually install) the same way — mount it,
+# then check signature, entitlements, and the bundled runtime on the app inside.
+dmg_path="$(find_dmg)"
+if [[ -n "$dmg_path" ]]; then
+  echo "[verify-macos-update] Verifying DMG: ${dmg_path}"
+  dmg_mnt="$(mktemp -d "${TMPDIR:-/tmp}/autodoc-mac-dmg-verify.XXXXXX")"
+  detach_dmg() {
+    hdiutil detach -quiet "$dmg_mnt" >/dev/null 2>&1 || hdiutil detach "$dmg_mnt" >/dev/null 2>&1 || true
+    rmdir "$dmg_mnt" 2>/dev/null || true
+  }
+  trap 'detach_dmg; cleanup' EXIT
+  hdiutil attach -nobrowse -quiet -mountpoint "$dmg_mnt" "$dmg_path"
+
+  dmg_app="${dmg_mnt}/${APP_NAME}"
+  dmg_rc=0
+  (
+    verify_app_entitlements "$dmg_app"
+    verify_app_signature "$dmg_app"
+    verify_app_runtime "$dmg_app"
+  ) || dmg_rc=$?
+
+  detach_dmg
+  trap cleanup EXIT
+  [[ "$dmg_rc" == "0" ]] || die "DMG verification failed for ${dmg_path}"
+  echo "[verify-macos-update] DMG OK"
+else
+  echo "[verify-macos-update] No DMG found in ${ARTIFACT_DIR}; skipping DMG verification"
+fi
+
 echo "[verify-macos-update] OK"

--- a/src/main/ipc/calendar-ipc.ts
+++ b/src/main/ipc/calendar-ipc.ts
@@ -32,22 +32,40 @@ export function registerCalendarIpc(
     try {
       const account = await calendarManager.connect(providerType)
 
-      const events = await calendarManager.fetchAllUpcomingEvents()
-      const enriched = applyAutoRecordState(events)
-      pushEventsToRenderer(enriched)
-      onEventsUpdated?.(enriched)
-
-      // Start sync if this is the first account
-      if (calendarManager.getAccounts().length === 1) {
-        calendarManager.startSync((updatedEvents) => {
-          const enrichedUpdated = applyAutoRecordState(updatedEvents)
-          pushEventsToRenderer(enrichedUpdated)
-          onEventsUpdated?.(enrichedUpdated)
-        })
-      }
-
+      // Announce the connection and return as soon as the account is saved.
+      // Fetching upcoming events is a second network round-trip; if we block the
+      // IPC return (and the connection-changed broadcast) on it, the renderer's
+      // focus-abandon timer can fire first and discard the success, leaving
+      // onboarding stuck on the connect screen until relaunch. Events are pushed
+      // best-effort below and the renderer also listens for calendar:events-updated.
       pushConnectionStatus(true)
       onConnectionChanged?.(true)
+
+      void (async () => {
+        try {
+          const events = await calendarManager.fetchAllUpcomingEvents()
+          const enriched = applyAutoRecordState(events)
+          pushEventsToRenderer(enriched)
+          onEventsUpdated?.(enriched)
+
+          // Start sync if this is the first account
+          if (calendarManager.getAccounts().length === 1) {
+            calendarManager.startSync((updatedEvents) => {
+              const enrichedUpdated = applyAutoRecordState(updatedEvents)
+              pushEventsToRenderer(enrichedUpdated)
+              onEventsUpdated?.(enrichedUpdated)
+            })
+          }
+        } catch (err) {
+          logAutodocFailure({
+            area: 'calendar',
+            message: 'Failed to fetch events after calendar connection',
+            error: err,
+            context: { provider: providerType }
+          })
+        }
+      })()
+
       return account
     } catch (err) {
       logAutodocFailure({

--- a/src/main/services/calendar.ts
+++ b/src/main/services/calendar.ts
@@ -77,12 +77,17 @@ export class GoogleCalendarProvider implements CalendarProvider {
     this.clients.set(accountId, client)
     saveTokensForAccount(accountId, result.tokens)
 
-    const email = await this.fetchAccountEmail(accountId)
+    // The OAuth id_token already carries the account email, so read it locally to
+    // return immediately. Only fall back to the network lookup (calendar list /
+    // userinfo) when the token doesn't include it, so a successful sign-in surfaces
+    // to the UI without waiting on an extra round-trip.
+    const idToken = (result.tokens as { id_token?: string }).id_token
+    const email = extractEmailFromIdToken(idToken) ?? (await this.fetchAccountEmail(accountId)) ?? ''
 
     return {
       id: accountId,
       provider: 'google',
-      email: email ?? '',
+      email,
       connectedAt: Date.now(),
     }
   }
@@ -159,6 +164,10 @@ export class GoogleCalendarProvider implements CalendarProvider {
         return new Promise((resolveClose) => {
           try {
             server.close(() => resolveClose())
+            // The browser keeps the loopback socket alive, so server.close() would
+            // otherwise wait for its idle timeout (the 2-3s "stuck connecting" lag).
+            // Drop those sockets so close() resolves right away.
+            ;(server as { closeAllConnections?: () => void }).closeAllConnections?.()
           } catch {
             // The server may not have started listening yet.
             resolveClose()
@@ -178,13 +187,17 @@ export class GoogleCalendarProvider implements CalendarProvider {
       function resolveAndClose(result: { tokens: object }): void {
         if (settled) return
         settled = true
-        void cleanup().then(() => resolve(result))
+        // Surface the result immediately; tokens are already in hand. Tearing down
+        // the loopback server is just cleanup and must not delay the UI.
+        resolve(result)
+        void cleanup()
       }
 
       function rejectAndClose(error: Error): void {
         if (settled) return
         settled = true
-        void cleanup().then(() => reject(error))
+        reject(error)
+        void cleanup()
       }
 
       server.listen(OAUTH_PORT, '127.0.0.1')

--- a/src/main/services/microsoft-calendar.ts
+++ b/src/main/services/microsoft-calendar.ts
@@ -96,12 +96,15 @@ export class MicrosoftCalendarProvider implements CalendarProvider {
     saveTokensForAccount(accountId, tokens)
     this.tokenCache.set(accountId, tokens)
 
-    const email = await this.fetchAccountEmail(accountId)
+    // The OAuth id_token already carries the account email, so read it locally to
+    // return immediately and only fall back to the network lookup when missing.
+    const idToken = (tokens as { id_token?: string }).id_token
+    const email = extractEmailFromIdToken(idToken) ?? (await this.fetchAccountEmail(accountId)) ?? ''
 
     return {
       id: accountId,
       provider: 'microsoft',
-      email: email ?? '',
+      email,
       connectedAt: Date.now(),
     }
   }
@@ -173,6 +176,10 @@ export class MicrosoftCalendarProvider implements CalendarProvider {
         return new Promise((resolveClose) => {
           try {
             server.close(() => resolveClose())
+            // The browser keeps the loopback socket alive, so server.close() would
+            // otherwise wait for its idle timeout (the 2-3s "stuck connecting" lag).
+            // Drop those sockets so close() resolves right away.
+            ;(server as { closeAllConnections?: () => void }).closeAllConnections?.()
           } catch {
             // The server may not have started listening yet.
             resolveClose()
@@ -192,13 +199,17 @@ export class MicrosoftCalendarProvider implements CalendarProvider {
       function resolveAndClose(result: { tokens: OAuthTokens & { expires_in?: number } }): void {
         if (settled) return
         settled = true
-        void cleanup().then(() => resolve(result))
+        // Surface the result immediately; tokens are already in hand. Tearing down
+        // the loopback server is just cleanup and must not delay the UI.
+        resolve(result)
+        void cleanup()
       }
 
       function rejectAndClose(error: Error): void {
         if (settled) return
         settled = true
-        void cleanup().then(() => reject(error))
+        reject(error)
+        void cleanup()
       }
 
       server.listen(OAUTH_PORT, '127.0.0.1')

--- a/src/renderer/src/hooks/useCalendarConnect.ts
+++ b/src/renderer/src/hooks/useCalendarConnect.ts
@@ -1,12 +1,13 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import type { CalendarAccount } from '../../../shared/types'
+import { recordPersistentDiagnosticAction } from '../services/diagnostic-trail'
 
 type CalendarProviderType = 'google' | 'microsoft'
 
 interface UseCalendarConnectOptions {
   /** Called after a connection completes and is still the active attempt. */
   onConnected?: (account: CalendarAccount, provider: CalendarProviderType) => void | Promise<void>
-  /** Called when an active attempt fails (cancelled/superseded attempts are ignored). */
+  /** Called when an active attempt fails (superseded attempts are ignored). */
   onError?: (provider: CalendarProviderType, error: unknown) => void
   /** Builds the user-facing error message for a failed attempt. */
   formatError?: (provider: CalendarProviderType) => string
@@ -25,78 +26,53 @@ const PROVIDER_LABEL: Record<CalendarProviderType, string> = {
   microsoft: 'Microsoft Outlook'
 }
 
-// Completing OAuth in the browser returns focus to the app at almost the same
-// moment the loopback callback resolves `calendar:connect`. If we abandon the
-// attempt the instant focus returns, that success resolution is dropped and the
-// UI never advances (e.g. the onboarding "Continue" button never appears until
-// a relaunch re-reads the persisted account). Give the in-flight attempt a short
-// grace period to resolve on its own before treating the refocus as an
-// abandoned (tab-closed) flow.
-const FOCUS_ABANDON_GRACE_MS = 2500
-
 /**
  * Shared calendar-connect handling for every surface (onboarding, homepage banner,
- * settings).
+ * settings). There are exactly three states, driven directly by the OAuth result:
  *
- * The OAuth flow opens an external browser and the main process waits on a loopback
- * callback. If the user closes that tab without finishing, the attempt is abandoned
- * and the main-process `CalendarManager` stays "connecting". This hook recovers from
- * that in two ways:
+ *  1. Connecting — pressing connect opens the external OAuth browser and shows a
+ *     disabled "Connecting" button until the attempt settles. We intentionally do
+ *     NOT clear this when the browser opens (a window `blur`): doing so flips the
+ *     button back the instant it was pressed, which reads as a visual hitch. While
+ *     the user is off in the browser the app is backgrounded, so the disabled state
+ *     isn't even visible — and the connect IPC now resolves the moment tokens
+ *     arrive, so it clears on its own right as they return.
+ *  2. Success — the awaited `calendar:connect` resolves with the account, which we
+ *     surface through `onConnected` (e.g. onboarding shows Continue; settings adds
+ *     the account to the list).
+ *  3. Failure — the awaited `calendar:connect` rejects, which we surface as `error`.
  *
- *  - When the app window regains focus while an attempt is in flight (i.e. the user
- *    came back from the browser without completing the flow), it cancels the pending
- *    connection via `calendar:cancel-connect`.
- *  - It tracks the active attempt so a late-arriving resolution/rejection from a
- *    cancelled or superseded attempt is ignored instead of surfacing a spurious
- *    success or error.
- *
- * The main process additionally supersedes an in-flight attempt when a new one
- * starts, so pressing the button again from any surface also recovers.
+ * Abandoned OAuth (the user closes the tab without finishing) is the one case the
+ * IPC can't settle quickly, so we clear "Connecting" when the window regains focus
+ * — i.e. the user came back without completing the flow. That fires on return, not
+ * on hand-off, so it never causes the click-time flash. A successful attempt has
+ * already resolved by then, making this a no-op for the happy path. An `attemptId`
+ * token makes a superseded attempt's late resolution/rejection a no-op so it can't
+ * surface a stale success or error.
  */
 export function useCalendarConnect(options: UseCalendarConnectOptions = {}): UseCalendarConnectResult {
   const [connectingProvider, setConnectingProvider] = useState<CalendarProviderType | null>(null)
   const [error, setError] = useState<string | null>(null)
   const attemptRef = useRef<symbol | null>(null)
 
-  // Keep callbacks in a ref so the focus listener and connect callback stay stable.
+  // Keep callbacks in a ref so the connect callback stays stable.
   const optionsRef = useRef(options)
   optionsRef.current = options
 
   useEffect(() => {
-    let abandonTimer: ReturnType<typeof setTimeout> | null = null
-
-    const handleFocus = (): void => {
-      const activeAttempt = attemptRef.current
-      if (!activeAttempt) return
-      if (abandonTimer) return
-
-      // The user just returned to the app. They may have completed OAuth (the
-      // loopback callback resolves at roughly the same moment focus returns) or
-      // abandoned it (closed the tab). Wait briefly: if the attempt resolves on
-      // its own we leave it alone; otherwise we treat it as abandoned and cancel
-      // so the next press isn't blocked.
-      abandonTimer = setTimeout(() => {
-        abandonTimer = null
-        if (attemptRef.current !== activeAttempt) return
-
-        attemptRef.current = null
-        setConnectingProvider(null)
-        void window.electronAPI.invoke('calendar:cancel-connect').catch((err) => {
-          console.error('Failed to cancel calendar connection:', err)
-        })
-      }, FOCUS_ABANDON_GRACE_MS)
-    }
-
+    // Returning to the app while still "Connecting" means the user came back without
+    // finishing OAuth (a successful attempt would already have resolved). Drop the
+    // disabled state so they can retry. We only clear the display, NOT the attempt
+    // token: if the awaited IPC is about to resolve (they returned a beat early), the
+    // success still surfaces. A re-press supersedes any genuinely abandoned flow.
+    const handleFocus = (): void => setConnectingProvider(null)
     window.addEventListener('focus', handleFocus)
-    return () => {
-      window.removeEventListener('focus', handleFocus)
-      if (abandonTimer) clearTimeout(abandonTimer)
-    }
+    return () => window.removeEventListener('focus', handleFocus)
   }, [])
 
   const connect = useCallback(async (provider: CalendarProviderType): Promise<void> => {
-    if (attemptRef.current) return
-
+    // A new attempt supersedes any previous one (the main process cancels the
+    // earlier loopback flow), so we don't block re-presses.
     const attemptId = Symbol(provider)
     attemptRef.current = attemptId
     setConnectingProvider(provider)
@@ -105,9 +81,15 @@ export function useCalendarConnect(options: UseCalendarConnectOptions = {}): Use
     try {
       const account = await window.electronAPI.invoke('calendar:connect', provider)
       if (attemptRef.current !== attemptId) return
+      // Definitive marker that the UI surfaced a connected calendar without a relaunch.
+      recordPersistentDiagnosticAction({
+        category: 'system',
+        action: 'calendar_connected',
+        details: { provider }
+      })
       await optionsRef.current.onConnected?.(account, provider)
     } catch (err) {
-      // A cancelled or superseded attempt is no longer the active one — stay quiet.
+      // A superseded attempt is no longer the active one — stay quiet.
       if (attemptRef.current !== attemptId) return
       console.error('Failed to connect calendar:', err)
       optionsRef.current.onError?.(provider, err)

--- a/src/renderer/src/hooks/useCalendarConnect.ts
+++ b/src/renderer/src/hooks/useCalendarConnect.ts
@@ -25,6 +25,15 @@ const PROVIDER_LABEL: Record<CalendarProviderType, string> = {
   microsoft: 'Microsoft Outlook'
 }
 
+// Completing OAuth in the browser returns focus to the app at almost the same
+// moment the loopback callback resolves `calendar:connect`. If we abandon the
+// attempt the instant focus returns, that success resolution is dropped and the
+// UI never advances (e.g. the onboarding "Continue" button never appears until
+// a relaunch re-reads the persisted account). Give the in-flight attempt a short
+// grace period to resolve on its own before treating the refocus as an
+// abandoned (tab-closed) flow.
+const FOCUS_ABANDON_GRACE_MS = 2500
+
 /**
  * Shared calendar-connect handling for every surface (onboarding, homepage banner,
  * settings).
@@ -54,20 +63,35 @@ export function useCalendarConnect(options: UseCalendarConnectOptions = {}): Use
   optionsRef.current = options
 
   useEffect(() => {
-    const handleFocus = (): void => {
-      if (!attemptRef.current) return
+    let abandonTimer: ReturnType<typeof setTimeout> | null = null
 
-      // The user returned to the app without completing OAuth (e.g. closed the tab).
-      // Abandon the in-flight attempt so the next press isn't blocked.
-      attemptRef.current = null
-      setConnectingProvider(null)
-      void window.electronAPI.invoke('calendar:cancel-connect').catch((err) => {
-        console.error('Failed to cancel calendar connection:', err)
-      })
+    const handleFocus = (): void => {
+      const activeAttempt = attemptRef.current
+      if (!activeAttempt) return
+      if (abandonTimer) return
+
+      // The user just returned to the app. They may have completed OAuth (the
+      // loopback callback resolves at roughly the same moment focus returns) or
+      // abandoned it (closed the tab). Wait briefly: if the attempt resolves on
+      // its own we leave it alone; otherwise we treat it as abandoned and cancel
+      // so the next press isn't blocked.
+      abandonTimer = setTimeout(() => {
+        abandonTimer = null
+        if (attemptRef.current !== activeAttempt) return
+
+        attemptRef.current = null
+        setConnectingProvider(null)
+        void window.electronAPI.invoke('calendar:cancel-connect').catch((err) => {
+          console.error('Failed to cancel calendar connection:', err)
+        })
+      }, FOCUS_ABANDON_GRACE_MS)
     }
 
     window.addEventListener('focus', handleFocus)
-    return () => window.removeEventListener('focus', handleFocus)
+    return () => {
+      window.removeEventListener('focus', handleFocus)
+      if (abandonTimer) clearTimeout(abandonTimer)
+    }
   }, [])
 
   const connect = useCallback(async (provider: CalendarProviderType): Promise<void> => {

--- a/src/renderer/src/pages/Settings.test.tsx
+++ b/src/renderer/src/pages/Settings.test.tsx
@@ -132,21 +132,25 @@ describe('Settings', () => {
     ).toBeChecked()
   })
 
-  it('cancels an abandoned calendar connection when the app regains focus', async () => {
+  it('keeps connecting while in the browser, clears it on return, and still surfaces a late success', async () => {
+    const existing = createCalendarAccount({
+      id: 'acct-existing',
+      email: 'existing@example.com',
+      connectedAt: new Date('2026-04-16T09:00:00Z').getTime()
+    })
+    const connectedAccount = createCalendarAccount({ id: 'acct-new', email: 'new@example.com' })
     const state = {
-      accounts: [createCalendarAccount({ email: 'existing@example.com' })],
+      accounts: [existing] as ReturnType<typeof createCalendarAccount>[],
       events: [] as any[],
       analyticsConsent: false,
       diagnosticLogUploadConsent: false
     }
-    const abandonedAccount = createCalendarAccount({ email: 'abandoned@example.com' })
-    let resolveConnect!: (account: typeof abandonedAccount) => void
-    const connectPromise = new Promise<typeof abandonedAccount>((resolve) => {
+    let resolveConnect!: (account: typeof connectedAccount) => void
+    const connectPromise = new Promise<typeof connectedAccount>((resolve) => {
       resolveConnect = resolve
     })
-    const getEvents = vi.fn(() => state.events)
 
-    const api = installMockElectronApi({
+    installMockElectronApi({
       'app:get-version': '0.1.11',
       'updater:get-status': createUpdateStatus(),
       'app:get-runtime-info': createRuntimeInfo(),
@@ -154,9 +158,9 @@ describe('Settings', () => {
       'prefs:get-analytics-consent': () => state.analyticsConsent,
       'prefs:get-diagnostic-log-upload-consent': () => state.diagnosticLogUploadConsent,
       'calendar:get-accounts': () => state.accounts,
-      'calendar:get-events': getEvents,
-      'calendar:connect': () => connectPromise,
-      'calendar:cancel-connect': undefined
+      'calendar:get-events': () => state.events,
+      // The OAuth flow is still in the external browser — the IPC hasn't resolved yet.
+      'calendar:connect': () => connectPromise
     })
 
     const user = userEvent.setup()
@@ -165,31 +169,35 @@ describe('Settings', () => {
     expect(await screen.findByText('existing@example.com')).toBeInTheDocument()
 
     await user.click(screen.getByRole('button', { name: /add google calendar/i }))
-
     expect(screen.getByRole('button', { name: /connecting/i })).toBeDisabled()
-    expect(screen.getByRole('button', { name: /add microsoft outlook/i })).toBeDisabled()
 
+    // Handing off to the OAuth browser (window `blur`) must NOT flip the button back —
+    // doing so caused a click-time flash. It stays "Connecting".
+    act(() => {
+      window.dispatchEvent(new Event('blur'))
+    })
+    expect(screen.getByRole('button', { name: /connecting/i })).toBeDisabled()
+
+    // Returning to the app (window `focus`) clears the disabled state so an abandoned
+    // attempt can be retried.
     act(() => {
       window.dispatchEvent(new Event('focus'))
     })
-
     await waitFor(() => {
       expect(screen.getByRole('button', { name: /add google calendar/i })).toBeEnabled()
       expect(screen.getByRole('button', { name: /add microsoft outlook/i })).toBeEnabled()
     })
     expect(screen.queryByRole('button', { name: /connecting/i })).not.toBeInTheDocument()
-    expect(api.invoke).toHaveBeenCalledWith('calendar:cancel-connect')
 
-    getEvents.mockClear()
+    // The user actually finished in the browser, so the awaited connection still
+    // resolves and surfaces the account even though we cleared the display on return.
+    state.accounts = [existing, connectedAccount]
     await act(async () => {
-      resolveConnect(abandonedAccount)
+      resolveConnect(connectedAccount)
       await connectPromise
     })
 
-    expect(screen.queryByText('abandoned@example.com')).not.toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /add google calendar/i })).toBeEnabled()
-    expect(screen.getByRole('button', { name: /add microsoft outlook/i })).toBeEnabled()
-    expect(getEvents).not.toHaveBeenCalled()
+    expect(await screen.findByText('new@example.com')).toBeInTheDocument()
   })
 
   it('does not render the speaker diarization toggle', async () => {


### PR DESCRIPTION
## Summary

QA's recurring **"transcription setup" failure** (and the related "AutoDoc doesn't appear in Privacy > Microphone") on the `0.1.47` release was caused by the bundled MLX/Python transcription runtime being killed by macOS Hardened Runtime.

**Root cause:** PR #19 (the `bugFix06.12.26` merge) added `mac.signIgnore: ['^.*?/Contents/Resources/.*$']`. That stops electron-builder's signer from applying the inherited entitlements to the bundled runtime. The `afterPack` script then re-signs those binaries with `--options runtime` but **no entitlements**, so the bundled `python3` ended up with Hardened Runtime enabled but without `allow-jit` / `allow-unsigned-executable-memory`. The moment the app imports `mlx_whisper`, MLX/scipy allocate executable (JIT) memory and macOS SIGKILLs the process:

```
signal: SIGKILL (Code Signature Invalid)
termination: { namespace: CODESIGNING, indicator: Invalid Page }   # VM_ALLOCATE r-x (JIT) region
```

`codesign --verify --deep --strict`, `spctl`, and notarization all pass on the `0.1.47` bundle — the signature is valid; it just lacks a runtime entitlement. That's why the existing CI checks never caught it. (Note: the earlier "226 detached `com.apple.cs.*` xattrs / invalid signature" theory was a red herring — those xattrs are normal and present in every valid notarized build.)

## Changes

1. **afterPack signs the bundled runtime with the app entitlements** (`build/entitlements.mac.plist` → `allow-jit`, `allow-unsigned-executable-memory`, `allow-dyld-environment-variables`), restoring what signing inheritance provided before `signIgnore`.
2. **CI runtime probe** — `verify-macos-update-artifact.sh` now asserts `allow-jit` on the bundled `python3` and actually runs `import mlx_whisper`, so this regression class fails the build instead of shipping.
3. **DMG verification** — the verify script now mounts and verifies the `.dmg` (the artifact users install), not just the auto-update `.zip`.

## Verification (v0.1.48, built from this branch)

- CI `Verify macOS artifacts` step passed: DMG `valid on disk` + `satisfies its Designated Requirement`, `Runtime import probe OK`.
- Downloaded the notarized `v0.1.48` DMG and ran the bundled interpreter on macOS 26.5.1 (the OS where `0.1.47` failed):
  - `0.1.47`: `import mlx_whisper` → **SIGKILL (137)**
  - `0.1.48`: `import mlx_whisper` → **RC=0, OK**; bundled `python3` now carries `allow-jit` + `allow-unsigned-executable-memory`.

## Test plan

- [x] CI build + new verify step green on `v0.1.48`
- [x] Notarized `v0.1.48` runtime imports without SIGKILL on macOS 26
- [ ] QA: clean install `v0.1.48`, confirm transcription setup completes
- [ ] QA: confirm AutoDoc appears in System Settings > Privacy > Microphone after onboarding