### PR TITLE
Show up-to-date banner after update checks

### DIFF
--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -52,6 +52,7 @@ describe('App', () => {
 
   afterEach(() => {
     window.location.hash = '#/'
+    vi.useRealTimers()
   })
 
   it('shows onboarding when the first-run flow is not complete yet', async () => {
@@ -192,6 +193,83 @@ describe('App', () => {
     await waitFor(() => {
       expect(window.electronAPI.invoke).toHaveBeenCalledWith('updater:install')
     })
+  })
+
+  it('shows the up to date banner in the app banner stack after a manual update check finds no updates', async () => {
+    window.location.hash = '#/settings'
+    const api = installMockElectronApi({
+      'prefs:get-onboarding-complete': true,
+      'prefs:get-analytics-consent': false,
+      'calendar:get-accounts': [],
+      'calendar:get-events': [],
+      'updater:get-status': createUpdateStatus(),
+      'updater:check': undefined,
+      'app:get-version': '0.1.11',
+      'app:get-runtime-info': undefined,
+      'app:get-storage-info': undefined,
+      'prefs:get-diagnostic-log-upload-consent': false
+    })
+
+    render(<App />)
+
+    const settingsHeading = await screen.findByRole('heading', { name: 'Settings' })
+    await userEvent.click(screen.getByRole('button', { name: /check for updates/i }))
+
+    await waitFor(() => {
+      expect(api.invoke).toHaveBeenCalledWith('updater:check')
+    })
+
+    expect(screen.queryByText("You're up to date")).not.toBeInTheDocument()
+
+    act(() => {
+      api.emit('updater:status', createUpdateStatus({ state: 'checking' }))
+    })
+    act(() => {
+      api.emit('updater:status', createUpdateStatus({ state: 'idle' }))
+    })
+
+    const bannerTitle = await screen.findByText("You're up to date")
+    expect(screen.getByText('AutoDoc is running the latest available version.')).toBeInTheDocument()
+    expect(
+      Boolean(bannerTitle.compareDocumentPosition(settingsHeading) & Node.DOCUMENT_POSITION_FOLLOWING)
+    ).toBe(true)
+
+    await userEvent.click(screen.getByRole('button', { name: /dismiss up to date message/i }))
+
+    await waitFor(() => {
+      expect(screen.queryByText("You're up to date")).not.toBeInTheDocument()
+    })
+  })
+
+  it('auto dismisses the up to date banner from the app banner stack', async () => {
+    const api = installMockElectronApi({
+      'prefs:get-onboarding-complete': true,
+      'prefs:get-analytics-consent': false,
+      'calendar:get-accounts': [],
+      'calendar:get-events': [],
+      'updater:get-status': createUpdateStatus()
+    })
+
+    render(<App />)
+
+    expect(await screen.findByRole('heading', { name: 'Upcoming' })).toBeInTheDocument()
+
+    vi.useFakeTimers()
+    act(() => {
+      window.dispatchEvent(new Event('autodoc:manual-update-check'))
+      api.emit('updater:status', createUpdateStatus({ state: 'checking' }))
+    })
+    act(() => {
+      api.emit('updater:status', createUpdateStatus({ state: 'idle' }))
+    })
+
+    expect(screen.getByText("You're up to date")).toBeInTheDocument()
+
+    act(() => {
+      vi.advanceTimersByTime(6_000)
+    })
+
+    expect(screen.queryByText("You're up to date")).not.toBeInTheDocument()
   })
 
   it('opens Settings when the update notification is clicked', async () => {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -35,6 +35,7 @@ import {
 } from './services/analytics'
 import { recordDiagnosticAction, setDiagnosticConsentEnabled } from './services/diagnostic-trail'
 import { updateRendererSentryConsent } from './services/renderer-sentry'
+import { onManualUpdateCheckStarted } from './services/update-check-events'
 import { useCalendarStore } from './stores/calendar'
 import { getSavedSourcePreference } from './services/recording-source-preferences'
 import { useRecordingPickerStore } from './stores/recording-picker'
@@ -59,33 +60,119 @@ function RouteDiagnosticTracker() {
 function UpdateReadyPrompt() {
   const [updateStatus, setUpdateStatus] = useState<UpdateStatus | null>(null)
   const [dismissedVersion, setDismissedVersion] = useState<string | null>(null)
+  const [showUpToDateBanner, setShowUpToDateBanner] = useState(false)
   const location = useLocation()
+  const previousUpdateState = useRef<UpdateStatus['state']>('idle')
+  const manualUpdateCheckPending = useRef(false)
 
   useEffect(() => {
     let cancelled = false
 
-    window.electronAPI.invoke('updater:get-status').then((status) => {
-      if (!cancelled) {
-        setUpdateStatus(status)
+    const applyUpdateStatus = (status: UpdateStatus | undefined) => {
+      if (cancelled || !status) {
+        return
       }
-    })
 
-    const unsubscribeStatus = window.electronAPI.on('updater:status', (status) => {
       setUpdateStatus(status)
       if (status.state !== 'downloaded') {
         setDismissedVersion(null)
       }
+
+      const previousState = previousUpdateState.current
+      previousUpdateState.current = status.state
+
+      if (
+        status.state === 'idle' &&
+        previousState === 'checking' &&
+        manualUpdateCheckPending.current
+      ) {
+        manualUpdateCheckPending.current = false
+        setShowUpToDateBanner(true)
+        return
+      }
+
+      if (status.state === 'checking') {
+        setShowUpToDateBanner(false)
+        return
+      }
+
+      if (status.state !== 'idle') {
+        manualUpdateCheckPending.current = false
+        setShowUpToDateBanner(false)
+      }
+    }
+
+    window.electronAPI.invoke('updater:get-status').then(applyUpdateStatus)
+
+    const unsubscribeManualCheck = onManualUpdateCheckStarted(() => {
+      manualUpdateCheckPending.current = true
+      setShowUpToDateBanner(false)
     })
+    const unsubscribeStatus = window.electronAPI.on('updater:status', applyUpdateStatus)
     const unsubscribeOpenSettings = window.electronAPI.on('updater:open-settings', () => {
       window.location.hash = `#${ROUTES.settings}`
     })
 
     return () => {
       cancelled = true
+      unsubscribeManualCheck()
       unsubscribeStatus()
       unsubscribeOpenSettings()
     }
   }, [])
+
+  useEffect(() => {
+    if (!showUpToDateBanner) {
+      return
+    }
+
+    const dismissTimer = window.setTimeout(() => setShowUpToDateBanner(false), 6_000)
+    return () => window.clearTimeout(dismissTimer)
+  }, [showUpToDateBanner])
+
+  if (showUpToDateBanner) {
+    return (
+      <div className="mx-6 mt-2 mb-0 bg-sage-light border border-sage/25 rounded-lg px-4 py-3 flex items-start gap-3 shadow-sm animate-[slideDown_300ms_ease]">
+        <span className="mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full bg-white text-sage shadow-[inset_0_0_0_1px_rgba(122,158,126,0.34)] [animation:checkCirclePop_420ms_ease-out]">
+          <svg
+            aria-hidden="true"
+            viewBox="0 0 20 20"
+            className="size-3.5 [animation:checkStroke_520ms_ease-out_120ms_both]"
+            fill="none"
+          >
+            <path
+              d="M5 10.3 8.3 13.5 15.2 6.5"
+              stroke="currentColor"
+              strokeWidth="2.2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </span>
+        <div className="min-w-0 flex-1">
+          <p className="text-[12px] font-semibold leading-5 text-sage-dark">You're up to date</p>
+          <p className="text-[11px] leading-5 text-ink-muted">
+            AutoDoc is running the latest available version.
+          </p>
+        </div>
+        <button
+          type="button"
+          aria-label="Dismiss up to date message"
+          onClick={() => setShowUpToDateBanner(false)}
+          className="flex size-6 shrink-0 items-center justify-center rounded-md text-sage-dark/70 transition-colors hover:bg-white/70 hover:text-sage-dark focus:outline-none focus:ring-2 focus:ring-sage/40"
+        >
+          <svg aria-hidden="true" viewBox="0 0 16 16" className="size-3.5" fill="none">
+            <path
+              d="M4 4 12 12M12 4 4 12"
+              stroke="currentColor"
+              strokeWidth="1.7"
+              strokeLinecap="round"
+            />
+          </svg>
+        </button>
+      </div>
+    )
+  }
 
   if (
     !updateStatus ||

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -59,3 +59,14 @@
   from { opacity: 0; transform: translateY(16px); }
   to { opacity: 1; transform: translateY(0); }
 }
+
+@keyframes checkCirclePop {
+  0% { opacity: 0; transform: scale(0.72); }
+  62% { opacity: 1; transform: scale(1.08); }
+  100% { opacity: 1; transform: scale(1); }
+}
+
+@keyframes checkStroke {
+  from { stroke-dasharray: 22; stroke-dashoffset: 22; }
+  to { stroke-dasharray: 22; stroke-dashoffset: 0; }
+}

--- a/src/renderer/src/pages/Settings.tsx
+++ b/src/renderer/src/pages/Settings.tsx
@@ -14,6 +14,7 @@ import {
   trackEvent
 } from '../services/analytics'
 import { recordDiagnosticAction } from '../services/diagnostic-trail'
+import { notifyManualUpdateCheckStarted } from '../services/update-check-events'
 
 function getCalendarAccountLabel(account: CalendarAccount): string {
   const email = account.email.trim()
@@ -186,6 +187,11 @@ export function Settings() {
     removeAccount(accountId)
     const events = await window.electronAPI.invoke('calendar:get-events')
     setEvents(events)
+  }
+
+  const handleCheckForUpdates = () => {
+    notifyManualUpdateCheckStarted()
+    void window.electronAPI.invoke('updater:check')
   }
 
   const handleToggleAnalytics = async () => {
@@ -499,7 +505,7 @@ export function Settings() {
               <span className="text-[12px] text-ink-muted">AutoDoc v{appVersion}</span>
               {updateStatus.state === 'idle' && (
                 <button
-                  onClick={() => window.electronAPI.invoke('updater:check')}
+                  onClick={handleCheckForUpdates}
                   className="text-[11px] font-medium text-sage hover:text-sage-dark transition-colors"
                 >
                   Check for updates
@@ -544,7 +550,7 @@ export function Settings() {
               )}
               {updateStatus.state === 'error' && (
                 <button
-                  onClick={() => window.electronAPI.invoke('updater:check')}
+                  onClick={handleCheckForUpdates}
                   className="text-[11px] font-medium text-clay hover:text-clay-dark transition-colors"
                 >
                   Update Failed. Retry

--- a/src/renderer/src/services/update-check-events.ts
+++ b/src/renderer/src/services/update-check-events.ts
@@ -1,0 +1,10 @@
+const MANUAL_UPDATE_CHECK_EVENT = 'autodoc:manual-update-check'
+
+export function notifyManualUpdateCheckStarted(): void {
+  window.dispatchEvent(new Event(MANUAL_UPDATE_CHECK_EVENT))
+}
+
+export function onManualUpdateCheckStarted(listener: () => void): () => void {
+  window.addEventListener(MANUAL_UPDATE_CHECK_EVENT, listener)
+  return () => window.removeEventListener(MANUAL_UPDATE_CHECK_EVENT, listener)
+}


### PR DESCRIPTION
## Summary
- Show an app-level "You're up to date" banner after a manual update check returns no update
- Keep the banner in the existing top app-window banner stack with dismiss and auto-dismiss behavior
- Add a small manual-update-check event helper and App-level coverage

## Tests
- npm run test:run -- src/renderer/src/App.test.tsx src/renderer/src/pages/Settings.test.tsx
- npm run typecheck:web