### PR TITLE
Fix Windows release automation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -163,10 +163,14 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
-  # Windows QA builds run on manual dispatch only; the signed release path stays
-  # tag-gated and dormant until Windows ships publicly.
+  # Manual dispatches produce unsigned QA installers. Version tags use the
+  # signed release path and feed the shared release publisher below.
   build-win:
-    if: github.event_name == 'workflow_dispatch' && (inputs.release_platform == 'windows' || inputs.release_platform == 'all')
+    if: >-
+      ${{
+        (github.event_name == 'push' && github.ref_type == 'tag' && startsWith(github.ref_name, 'v')) ||
+        (github.event_name == 'workflow_dispatch' && (inputs.release_platform == 'windows' || inputs.release_platform == 'all'))
+      }}
     runs-on: windows-2022
     permissions:
       contents: read
@@ -455,12 +459,13 @@ jobs:
         github.event_name == 'push' &&
         github.ref_type == 'tag' &&
         startsWith(github.ref_name, 'v') &&
-        needs.build-mac-release.result == 'success'
+        needs.build-mac-release.result == 'success' &&
+        needs.build-win.result == 'success'
       }}
     runs-on: ubuntu-latest
     needs:
       - build-mac-release
-      # - build-win  # Windows builds disabled — macOS-only for now
+      - build-win
     permissions:
       contents: write
       actions: read
@@ -485,12 +490,12 @@ jobs:
           name: release-macos-${{ steps.release_meta.outputs.release_tag }}
           path: release-assets/mac
 
-      # - name: Download Windows release assets
-      #   if: github.event_name == 'push' && github.ref_type == 'tag' && startsWith(github.ref_name, 'v') && needs.build-win.result == 'success'
-      #   uses: actions/download-artifact@v8.0.1
-      #   with:
-      #     name: release-windows-${{ steps.release_meta.outputs.release_tag }}
-      #     path: release-assets/win
+      - name: Download Windows release assets
+        if: needs.build-win.result == 'success'
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: release-windows-${{ steps.release_meta.outputs.release_tag }}
+          path: release-assets/win
 
       - name: Publish curated GitHub release assets
         env:
@@ -498,10 +503,7 @@ jobs:
           GH_REPO: ${{ github.repository }}
           RELEASE_TAG: ${{ steps.release_meta.outputs.release_tag }}
         run: |
-          assets=(release-assets/mac/*)
-          # if [ -d release-assets/win ]; then
-          #   assets+=(release-assets/win/*)
-          # fi
+          assets=(release-assets/mac/* release-assets/win/*)
 
           if gh release view "$RELEASE_TAG" -R "$GH_REPO" >/dev/null 2>&1; then
             gh release upload "$RELEASE_TAG" "${assets[@]}" --clobber -R "$GH_REPO"
@@ -525,3 +527,19 @@ jobs:
           while IFS= read -r asset_id; do
             gh api --method DELETE "repos/${GH_REPO}/releases/assets/${asset_id}"
           done <<<"$blockmap_ids"
+
+  update-readme-release-links:
+    if: >-
+      ${{
+        github.event_name == 'push' &&
+        github.ref_type == 'tag' &&
+        startsWith(github.ref_name, 'v') &&
+        needs.publish-release.result == 'success'
+      }}
+    needs:
+      - publish-release
+    permissions:
+      contents: write
+    uses: ./.github/workflows/update-readme-release-links.yml
+    with:
+      release_tag: ${{ github.ref_name }}

--- a/.github/workflows/update-readme-release-links.yml
+++ b/.github/workflows/update-readme-release-links.yml
@@ -1,11 +1,12 @@
 name: Update README Release Links
 
 on:
-  workflow_run:
-    workflows:
-      - Build & Release
-    types:
-      - completed
+  workflow_call:
+    inputs:
+      release_tag:
+        description: Release tag to publish in README.
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       release_tag:
@@ -19,7 +20,6 @@ permissions:
 
 jobs:
   update-readme:
-    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
 
     steps:
@@ -27,12 +27,12 @@ jobs:
         with:
           ref: main
 
-      - name: Resolve release DMG
+      - name: Resolve release assets
         id: release
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-          REQUESTED_TAG: ${{ github.event.inputs.release_tag || '' }}
+          REQUESTED_TAG: ${{ inputs.release_tag || '' }}
         run: |
           if [ -n "$REQUESTED_TAG" ]; then
             release_json="$(gh api "repos/${GH_REPO}/releases/tags/${REQUESTED_TAG}")"
@@ -61,13 +61,34 @@ jobs:
             exit 1
           fi
 
+          windows_asset="$(jq -r --arg version "$version" '
+            .assets
+            | map(select(.name == ("autodoc-" + $version + "-setup.exe")))
+            | .[0].name // empty
+          ' <<<"$release_json")"
+
+          if [ -z "$windows_asset" ]; then
+            windows_asset="$(jq -r '
+              .assets
+              | map(select(.name | test("^autodoc-[0-9].*-setup\\.exe$")))
+              | .[0].name // empty
+            ' <<<"$release_json")"
+          fi
+
+          if [ -z "$windows_asset" ]; then
+            echo "::error::No versioned AutoDoc Windows setup asset found for ${tag}"
+            exit 1
+          fi
+
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
           echo "dmg_asset=$dmg_asset" >> "$GITHUB_OUTPUT"
+          echo "windows_asset=$windows_asset" >> "$GITHUB_OUTPUT"
 
       - name: Update README
         env:
           RELEASE_TAG: ${{ steps.release.outputs.tag }}
           DMG_ASSET: ${{ steps.release.outputs.dmg_asset }}
+          WINDOWS_ASSET: ${{ steps.release.outputs.windows_asset }}
         run: node scripts/update-readme-release-links.mjs
 
       - name: Commit README update

--- a/docs/assets/badges/download-windows.svg
+++ b/docs/assets/badges/download-windows.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="230" height="44" viewBox="0 0 230 44" role="img" aria-label="Download AutoDoc for Windows">
+  <defs>
+    <linearGradient id="windows-badge-fill" x1="0" y1="0" x2="230" y2="44" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#1A1A17"/>
+      <stop offset="0.56" stop-color="#4A6B4E"/>
+      <stop offset="1" stop-color="#7A9E7E"/>
+    </linearGradient>
+    <filter id="windows-badge-shadow" x="-8" y="-8" width="246" height="60" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="2" stdDeviation="3" flood-color="#4A6B4E" flood-opacity="0.28"/>
+    </filter>
+  </defs>
+  <rect x="1" y="1" width="228" height="42" rx="12" fill="url(#windows-badge-fill)" filter="url(#windows-badge-shadow)"/>
+  <rect x="1.5" y="1.5" width="227" height="41" rx="11.5" fill="none" stroke="#FFFFFF" stroke-opacity="0.42"/>
+  <g fill="#FFFFFF">
+    <rect x="18" y="11" width="10.2" height="10.2" rx="0.9"/>
+    <rect x="30.2" y="11" width="10.2" height="10.2" rx="0.9"/>
+    <rect x="18" y="23.2" width="10.2" height="10.2" rx="0.9"/>
+    <rect x="30.2" y="23.2" width="10.2" height="10.2" rx="0.9"/>
+  </g>
+  <text x="54" y="20" fill="#FFFFFF" font-family="-apple-system, BlinkMacSystemFont, 'SF Pro Display', 'Segoe UI', sans-serif" font-size="11" font-weight="600" letter-spacing="0.6">DOWNLOAD AUTODOC</text>
+  <text x="54" y="33" fill="#FFFFFF" font-family="-apple-system, BlinkMacSystemFont, 'SF Pro Display', 'Segoe UI', sans-serif" font-size="15" font-weight="700">for Windows</text>
+</svg>

--- a/scripts/__tests__/update-readme-release-links.test.mjs
+++ b/scripts/__tests__/update-readme-release-links.test.mjs
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import test from 'node:test'
+
+import { updateReadmeReleaseLinks } from '../update-readme-release-links.mjs'
+
+const release = {
+  releaseTag: 'v1.1.0',
+  dmgAsset: 'autodoc-1.1.0.dmg',
+  windowsAsset: 'autodoc-1.1.0-setup.exe'
+}
+
+const originalReadme = `
+[![Download AutoDoc for macOS](docs/assets/badges/download-macos.svg)](https://example.com/old.dmg) <img src="docs/assets/badges/windows-coming-soon.svg" alt="Windows Coming Soon!" />
+
+[![Latest release](https://img.shields.io/badge/release-v1.0.0-7A9E7E?style=flat-square&labelColor=555555)](https://github.com/DuetDisplay/AutoDoc/releases/latest)
+
+## [⬇️ Download AutoDoc for macOS](https://example.com/old.dmg)
+
+1. **Download** \`autodoc-1.0.0.dmg\`.
+`
+
+test('updates both platform assets and the release badge', () => {
+  const { readme, version } = updateReadmeReleaseLinks(originalReadme, release)
+
+  assert.equal(version, '1.1.0')
+  assert.match(readme, /releases\/download\/v1\.1\.0\/autodoc-1\.1\.0\.dmg/)
+  assert.match(readme, /releases\/download\/v1\.1\.0\/autodoc-1\.1\.0-setup\.exe/)
+  assert.match(readme, /release-v1\.1\.0-/)
+  assert.doesNotMatch(readme, /Windows Coming Soon/)
+})
+
+test('is idempotent once both download badges exist', () => {
+  const first = updateReadmeReleaseLinks(originalReadme, release).readme
+  const second = updateReadmeReleaseLinks(first, release).readme
+
+  assert.equal(second, first)
+})
+
+test('supports the current repository README layout', () => {
+  const currentReadme = fs.readFileSync(new URL('../../README.md', import.meta.url), 'utf8')
+  const { readme } = updateReadmeReleaseLinks(currentReadme, release)
+
+  assert.match(readme, /autodoc-1\.1\.0-setup\.exe/)
+  assert.doesNotMatch(readme, /windows-coming-soon\.svg/)
+})

--- a/scripts/update-readme-release-links.mjs
+++ b/scripts/update-readme-release-links.mjs
@@ -1,56 +1,86 @@
 import fs from 'node:fs'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
 
-const releaseTag = process.env.RELEASE_TAG?.trim()
-const dmgAsset = process.env.DMG_ASSET?.trim()
+export function updateReadmeReleaseLinks(readme, { releaseTag, dmgAsset, windowsAsset }) {
+  const version = releaseTag.replace(/^v/, '')
+  const badgeVersion = releaseTag.replace(/-/g, '--')
+  const releasePageUrl = 'https://github.com/DuetDisplay/AutoDoc/releases/latest'
+  const dmgUrl = `https://github.com/DuetDisplay/AutoDoc/releases/download/${releaseTag}/${dmgAsset}`
+  const windowsUrl = `https://github.com/DuetDisplay/AutoDoc/releases/download/${releaseTag}/${windowsAsset}`
+  const releaseBadgeUrl = `https://img.shields.io/badge/release-${badgeVersion}-7A9E7E?style=flat-square&labelColor=555555`
 
-if (!releaseTag) {
-  throw new Error('RELEASE_TAG is required')
-}
+  function replaceRequired(pattern, replacement, description) {
+    if (!pattern.test(readme)) {
+      throw new Error(`Could not find ${description} in README.md`)
+    }
 
-if (!dmgAsset) {
-  throw new Error('DMG_ASSET is required')
-}
-
-const readmePath = new URL('../README.md', import.meta.url)
-const version = releaseTag.replace(/^v/, '')
-const badgeVersion = releaseTag.replace(/-/g, '--')
-const releasePageUrl = 'https://github.com/DuetDisplay/AutoDoc/releases/latest'
-const dmgUrl = `https://github.com/DuetDisplay/AutoDoc/releases/download/${releaseTag}/${dmgAsset}`
-const releaseBadgeUrl = `https://img.shields.io/badge/release-${badgeVersion}-7A9E7E?style=flat-square&labelColor=555555`
-
-let readme = fs.readFileSync(readmePath, 'utf8')
-
-function replaceRequired(pattern, replacement, description) {
-  if (!pattern.test(readme)) {
-    throw new Error(`Could not find ${description} in README.md`)
+    readme = readme.replace(pattern, replacement)
   }
 
-  readme = readme.replace(pattern, replacement)
+  replaceRequired(
+    /\[!\[Download AutoDoc for macOS\]\(docs\/assets\/badges\/download-macos\.svg\)\]\([^)]+\)/,
+    `[![Download AutoDoc for macOS](docs/assets/badges/download-macos.svg)](${dmgUrl})`,
+    'header macOS download badge link'
+  )
+
+  replaceRequired(
+    /(?:\[!\[Download AutoDoc for Windows\]\(docs\/assets\/badges\/download-windows\.svg\)\]\([^)]+\)|<img src="docs\/assets\/badges\/windows-coming-soon\.svg" alt="Windows Coming Soon!" \/>)/,
+    `[![Download AutoDoc for Windows](docs/assets/badges/download-windows.svg)](${windowsUrl})`,
+    'header Windows download badge or coming-soon marker'
+  )
+
+  replaceRequired(
+    /\[!\[Latest release\]\(https:\/\/img\.shields\.io\/badge\/release-[^)]+\)\]\(https:\/\/github\.com\/DuetDisplay\/AutoDoc\/releases\/latest\)/,
+    `[![Latest release](${releaseBadgeUrl})](${releasePageUrl})`,
+    'latest release badge'
+  )
+
+  replaceRequired(
+    /^## \[.*Download AutoDoc for macOS\]\([^)]+\)$/m,
+    `## [⬇️ Download AutoDoc for macOS](${dmgUrl})`,
+    'download section heading link'
+  )
+
+  replaceRequired(
+    /^1\. \*\*Download\*\* .*$/m,
+    `1. **Download** \`${dmgAsset}\`, or browse the [Releases](${releasePageUrl}) page for a specific version.`,
+    'download install step'
+  )
+
+  return { readme, version }
 }
 
-replaceRequired(
-  /\[!\[Download AutoDoc for macOS\]\(docs\/assets\/badges\/download-macos\.svg\)\]\([^)]+\)/,
-  `[![Download AutoDoc for macOS](docs/assets/badges/download-macos.svg)](${dmgUrl})`,
-  'header download badge link'
-)
+const isMain =
+  process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href
 
-replaceRequired(
-  /\[!\[Latest release\]\(https:\/\/img\.shields\.io\/badge\/release-[^)]+\)\]\(https:\/\/github\.com\/DuetDisplay\/AutoDoc\/releases\/latest\)/,
-  `[![Latest release](${releaseBadgeUrl})](${releasePageUrl})`,
-  'latest release badge'
-)
+if (isMain) {
+  const releaseTag = process.env.RELEASE_TAG?.trim()
+  const dmgAsset = process.env.DMG_ASSET?.trim()
+  const windowsAsset = process.env.WINDOWS_ASSET?.trim()
 
-replaceRequired(
-  /^## \[.*Download AutoDoc for macOS\]\([^)]+\)$/m,
-  `## [⬇️ Download AutoDoc for macOS](${dmgUrl})`,
-  'download section heading link'
-)
+  if (!releaseTag) {
+    throw new Error('RELEASE_TAG is required')
+  }
 
-replaceRequired(
-  /^1\. \*\*Download\*\* .*$/m,
-  `1. **Download** \`${dmgAsset}\`, or browse the [Releases](${releasePageUrl}) page for a specific version.`,
-  'download install step'
-)
+  if (!dmgAsset) {
+    throw new Error('DMG_ASSET is required')
+  }
 
-fs.writeFileSync(readmePath, readme)
-console.log(`Updated README.md for ${releaseTag} (${dmgAsset}, version ${version})`)
+  if (!windowsAsset) {
+    throw new Error('WINDOWS_ASSET is required')
+  }
+
+  const readmePath = new URL('../README.md', import.meta.url)
+  const currentReadme = fs.readFileSync(readmePath, 'utf8')
+  const result = updateReadmeReleaseLinks(currentReadme, {
+    releaseTag,
+    dmgAsset,
+    windowsAsset
+  })
+
+  fs.writeFileSync(readmePath, result.readme)
+  console.log(
+    `Updated README.md for ${releaseTag} (${dmgAsset}, ${windowsAsset}, version ${result.version})`
+  )
+}


### PR DESCRIPTION
## Summary

- run the signed Windows build for `v*` release tags
- require both macOS and Windows release jobs before publishing
- download and upload the Windows installer and update metadata with the macOS assets
- invoke README link updates only after successful release publication
- require and link both platform assets, with an idempotent updater test and Windows download badge

## Root cause

The Windows build and publisher paths were implemented but retained rollout guards from the macOS-only release: tag pushes did not start `build-win`, `publish-release` did not depend on it, and the Windows artifact download/upload steps remained commented out. The README updater also only resolved DMG assets and ran after every successful build rather than the completed tag release.

## Impact

Release publication now fails closed unless both signed platform builds succeed. Manual unsigned Windows QA dispatches continue to use the existing path. No packaged application code changes.

## Validation

- `node --test scripts/__tests__/update-readme-release-links.test.mjs` (3/3 passing)
- Prettier check for both workflows and updater files
- YAML parse for both workflow files
- `git diff --check`
- exact asset-resolution check for `autodoc-1.1.0.dmg` and `autodoc-1.1.0-setup.exe`
