### PR TITLE
Restore manual release recovery workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,11 @@ on:
           - mac
           - windows
           - all
+      release_tag:
+        description: Existing v* tag to build as a draft release (requires target "all"; leave blank for unsigned QA)
+        required: false
+        default: ''
+        type: string
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
@@ -27,11 +32,87 @@ env:
   AUTODOC_BUILDER_CONFIG_ARGS: ${{ github.repository == 'DuetDisplay/AutoDoc-Internal' && '--config electron-builder.internal.yml' || '' }}
 
 jobs:
+  validate-release-request:
+    if: >-
+      ${{
+        (github.event_name == 'push' && github.ref_type == 'tag' && startsWith(github.ref_name, 'v')) ||
+        (github.event_name == 'workflow_dispatch' && inputs.release_tag != '')
+      }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      release_tag: ${{ steps.release_meta.outputs.release_tag }}
+      release_version: ${{ steps.release_meta.outputs.release_version }}
+      release_sha: ${{ steps.verify_tag.outputs.release_sha }}
+
+    steps:
+      - name: Resolve release request
+        id: release_meta
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_TAG: ${{ github.ref_name }}
+          DISPATCH_TAG: ${{ inputs.release_tag }}
+          RELEASE_PLATFORM: ${{ inputs.release_platform }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            if [ "$RELEASE_PLATFORM" != "all" ]; then
+              echo "::error::Manual release recovery requires release_platform=all."
+              exit 1
+            fi
+            release_tag="$DISPATCH_TAG"
+          else
+            release_tag="$EVENT_TAG"
+          fi
+
+          if [[ ! "$release_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Release tag must be a valid v-prefixed version (for example, v1.1.0)."
+            exit 1
+          fi
+
+          echo "release_tag=$release_tag" >> "$GITHUB_OUTPUT"
+          echo "release_version=${release_tag#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Check out requested release tag
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: refs/tags/${{ steps.release_meta.outputs.release_tag }}
+          fetch-depth: 0
+
+      - name: Verify tag target and package version
+        id: verify_tag
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ steps.release_meta.outputs.release_tag }}
+          RELEASE_VERSION: ${{ steps.release_meta.outputs.release_version }}
+        run: |
+          release_sha="$(git rev-parse HEAD)"
+          tag_sha="$(git rev-parse "refs/tags/${RELEASE_TAG}^{commit}")"
+          package_version="$(node -p "require('./package.json').version")"
+
+          if [ "$release_sha" != "$tag_sha" ]; then
+            echo "::error::Checked-out commit does not match ${RELEASE_TAG}."
+            exit 1
+          fi
+
+          if [ "$package_version" != "$RELEASE_VERSION" ]; then
+            echo "::error::package.json version ${package_version} does not match ${RELEASE_TAG}."
+            exit 1
+          fi
+
+          echo "Validated ${RELEASE_TAG} at ${release_sha}."
+          echo "release_sha=$release_sha" >> "$GITHUB_OUTPUT"
+
   build-mac-ci:
     if: >-
       ${{
         (github.event_name == 'push' && github.ref_type == 'branch') ||
-        (github.event_name == 'workflow_dispatch' && (inputs.release_platform == 'mac' || inputs.release_platform == 'all'))
+        (
+          github.event_name == 'workflow_dispatch' &&
+          inputs.release_tag == '' &&
+          (inputs.release_platform == 'mac' || inputs.release_platform == 'all')
+        )
       }}
     runs-on: macos-latest
     permissions:
@@ -76,7 +157,17 @@ jobs:
           retention-days: 14
 
   build-mac-release:
-    if: github.event_name == 'push' && github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
+    needs:
+      - validate-release-request
+    if: >-
+      ${{
+        always() &&
+        needs.validate-release-request.result == 'success' &&
+        (
+          (github.event_name == 'push' && github.ref_type == 'tag' && startsWith(github.ref_name, 'v')) ||
+          (github.event_name == 'workflow_dispatch' && inputs.release_tag != '' && inputs.release_platform == 'all')
+        )
+      }}
     runs-on: macos-latest
     environment: release-signing
     permissions:
@@ -95,23 +186,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ needs.validate-release-request.outputs.release_sha }}
 
       - uses: actions/setup-node@v6.4.0
         with:
           node-version: 22
           cache: npm
-
-      - name: Resolve release metadata
-        id: release_meta
-        shell: bash
-        env:
-          RAW_TAG: ${{ github.ref_name }}
-        run: |
-          raw_tag="$RAW_TAG"
-          release_tag="${raw_tag#refs/tags/}"
-          release_version="${release_tag#v}"
-          echo "release_tag=$release_tag" >> "$GITHUB_OUTPUT"
-          echo "release_version=$release_version" >> "$GITHUB_OUTPUT"
 
       - name: Install dependencies
         run: npm ci
@@ -146,7 +227,7 @@ jobs:
         run: |
           npm run prepare:macos-mlx-runtime
           npm run build
-          npx electron-builder --mac --publish never "-c.extraMetadata.version=${{ steps.release_meta.outputs.release_version }}"
+          npx electron-builder --mac --publish never "-c.extraMetadata.version=${{ needs.validate-release-request.outputs.release_version }}"
 
       - name: Verify macOS release artifacts (signature, entitlements, runtime)
         run: bash scripts/verify-macos-update-artifact.sh dist
@@ -155,7 +236,7 @@ jobs:
         if: success()
         uses: actions/upload-artifact@v7.0.1
         with:
-          name: release-macos-${{ steps.release_meta.outputs.release_tag }}
+          name: release-macos-${{ needs.validate-release-request.outputs.release_tag }}
           path: |
             dist/*.dmg
             dist/*.zip
@@ -163,13 +244,29 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
-  # Manual dispatches produce unsigned QA installers. Version tags use the
-  # signed release path and feed the shared release publisher below.
+  # Manual dispatches without release_tag produce unsigned QA installers.
+  # Version tags and validated manual recovery requests use the signed release
+  # path and feed the shared release publisher below.
   build-win:
+    needs:
+      - validate-release-request
     if: >-
       ${{
-        (github.event_name == 'push' && github.ref_type == 'tag' && startsWith(github.ref_name, 'v')) ||
-        (github.event_name == 'workflow_dispatch' && (inputs.release_platform == 'windows' || inputs.release_platform == 'all'))
+        always() &&
+        (
+          (
+            needs.validate-release-request.result == 'success' &&
+            (
+              (github.event_name == 'push' && github.ref_type == 'tag' && startsWith(github.ref_name, 'v')) ||
+              (github.event_name == 'workflow_dispatch' && inputs.release_tag != '' && inputs.release_platform == 'all')
+            )
+          ) ||
+          (
+            github.event_name == 'workflow_dispatch' &&
+            inputs.release_tag == '' &&
+            (inputs.release_platform == 'windows' || inputs.release_platform == 'all')
+          )
+        )
       }}
     runs-on: windows-2022
     permissions:
@@ -184,9 +281,12 @@ jobs:
       VITE_POSTHOG_HOST: ${{ secrets.VITE_POSTHOG_HOST }}
       HF_TOKEN: ${{ secrets.HUGGINGFACE_TOKEN }}
       HUGGINGFACE_TOKEN: ${{ secrets.HUGGINGFACE_TOKEN }}
+      AUTODOC_SIGNED_RELEASE: ${{ needs.validate-release-request.result == 'success' && 'true' || 'false' }}
 
     steps:
       - uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ needs.validate-release-request.result == 'success' && needs.validate-release-request.outputs.release_sha || github.sha }}
 
       - uses: actions/setup-node@v6.4.0
         with:
@@ -194,11 +294,11 @@ jobs:
           cache: npm
 
       - name: Resolve release metadata
-        if: github.event_name == 'push' && github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
+        if: env.AUTODOC_SIGNED_RELEASE == 'true'
         id: release_meta
         shell: bash
         env:
-          RAW_TAG: ${{ github.ref_name }}
+          RAW_TAG: ${{ needs.validate-release-request.outputs.release_tag }}
         run: |
           raw_tag="$RAW_TAG"
           release_tag="${raw_tag#refs/tags/}"
@@ -218,7 +318,7 @@ jobs:
           }
 
       - name: Materialize DigiCert client certificate
-        if: github.event_name == 'push' && github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
+        if: env.AUTODOC_SIGNED_RELEASE == 'true'
         shell: pwsh
         env:
           SM_CLIENT_CERT_FILE_B64: ${{ secrets.DD_SM_CLIENT_CERT_FILE_B64 }}
@@ -228,7 +328,7 @@ jobs:
           "SM_CLIENT_CERT_FILE=$certPath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Setup DigiCert signing tools
-        if: github.event_name == 'push' && github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
+        if: env.AUTODOC_SIGNED_RELEASE == 'true'
         uses: digicert/code-signing-software-trust-action@v1.2.1
         with:
           use-github-caching-service: true
@@ -239,7 +339,7 @@ jobs:
           SM_CLIENT_CERT_PASSWORD: ${{ secrets.DD_SM_CLIENT_CERT_PASSWORD }}
 
       - name: Expose DigiCert tool paths
-        if: github.event_name == 'push' && github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
+        if: env.AUTODOC_SIGNED_RELEASE == 'true'
         shell: pwsh
         run: |
           $candidatePaths = @()
@@ -324,7 +424,7 @@ jobs:
           "SIGNTOOL_PATH=$signToolPath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Check DigiCert signing health
-        if: github.event_name == 'push' && github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
+        if: env.AUTODOC_SIGNED_RELEASE == 'true'
         shell: pwsh
         env:
           SM_HOST: https://clientauth.one.digicert.com
@@ -338,7 +438,7 @@ jobs:
           & $env:SMCTL_PATH windows certsync --keypair-alias=$env:SM_KEYPAIR_ALIAS --store=system
 
       - name: Build Windows release
-        if: github.event_name == 'push' && github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
+        if: env.AUTODOC_SIGNED_RELEASE == 'true'
         env:
           REQUIRE_WINDOWS_SIGNING: 'true'
           SM_HOST: https://clientauth.one.digicert.com
@@ -352,7 +452,7 @@ jobs:
           npx electron-builder --win --publish never "-c.extraMetadata.version=${{ steps.release_meta.outputs.release_version }}"
 
       - name: Verify Windows signatures
-        if: github.event_name == 'push' && github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
+        if: env.AUTODOC_SIGNED_RELEASE == 'true'
         shell: pwsh
         run: |
           $files = @(
@@ -389,7 +489,7 @@ jobs:
           }
 
       - name: Capture DigiCert signing diagnostics
-        if: github.event_name == 'push' && github.ref_type == 'tag' && startsWith(github.ref_name, 'v') && failure()
+        if: env.AUTODOC_SIGNED_RELEASE == 'true' && failure()
         shell: pwsh
         run: |
           $diagnosticDir = Join-Path $env:RUNNER_TEMP 'digicert-signing-diagnostics'
@@ -416,7 +516,7 @@ jobs:
           } | ConvertTo-Json | Out-File -FilePath (Join-Path $diagnosticDir 'environment.json') -Encoding utf8
 
       - name: Upload DigiCert signing diagnostics
-        if: github.event_name == 'push' && github.ref_type == 'tag' && startsWith(github.ref_name, 'v') && failure()
+        if: env.AUTODOC_SIGNED_RELEASE == 'true' && failure()
         uses: actions/upload-artifact@v7.0.1
         with:
           name: digicert-signing-diagnostics-${{ github.run_number }}
@@ -425,14 +525,14 @@ jobs:
           retention-days: 14
 
       - name: Build Windows artifacts
-        if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref_type == 'branch')
+        if: env.AUTODOC_SIGNED_RELEASE != 'true'
         # bash (not the default pwsh) so the optional $AUTODOC_BUILDER_CONFIG_ARGS
         # expands to separate arguments (or nothing when empty).
         shell: bash
         run: npm run build && npx electron-builder --win --publish never --config.win.forceCodeSigning=false $AUTODOC_BUILDER_CONFIG_ARGS
 
       - name: Upload Windows artifacts
-        if: (github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref_type == 'branch')) && success()
+        if: env.AUTODOC_SIGNED_RELEASE != 'true' && success()
         uses: actions/upload-artifact@v7.0.1
         with:
           name: autodoc-windows-${{ github.run_number }}
@@ -442,7 +542,7 @@ jobs:
           retention-days: 14
 
       - name: Upload Windows release assets
-        if: github.event_name == 'push' && github.ref_type == 'tag' && startsWith(github.ref_name, 'v') && success()
+        if: env.AUTODOC_SIGNED_RELEASE == 'true' && success()
         uses: actions/upload-artifact@v7.0.1
         with:
           name: release-windows-${{ steps.release_meta.outputs.release_tag }}
@@ -456,14 +556,17 @@ jobs:
     if: >-
       ${{
         always() &&
-        github.event_name == 'push' &&
-        github.ref_type == 'tag' &&
-        startsWith(github.ref_name, 'v') &&
+        needs.validate-release-request.result == 'success' &&
+        (
+          (github.event_name == 'push' && github.ref_type == 'tag' && startsWith(github.ref_name, 'v')) ||
+          (github.event_name == 'workflow_dispatch' && inputs.release_tag != '' && inputs.release_platform == 'all')
+        ) &&
         needs.build-mac-release.result == 'success' &&
         needs.build-win.result == 'success'
       }}
     runs-on: ubuntu-latest
     needs:
+      - validate-release-request
       - build-mac-release
       - build-win
     permissions:
@@ -471,42 +574,40 @@ jobs:
       actions: read
 
     steps:
-      - name: Resolve release metadata
-        id: release_meta
-        shell: bash
-        env:
-          RAW_TAG: ${{ github.ref_name }}
-        run: |
-          raw_tag="$RAW_TAG"
-          release_tag="${raw_tag#refs/tags/}"
-          release_version="${release_tag#v}"
-          echo "release_tag=$release_tag" >> "$GITHUB_OUTPUT"
-          echo "release_version=$release_version" >> "$GITHUB_OUTPUT"
-
       - name: Download macOS release assets
         if: needs.build-mac-release.result == 'success'
         uses: actions/download-artifact@v8.0.1
         with:
-          name: release-macos-${{ steps.release_meta.outputs.release_tag }}
+          name: release-macos-${{ needs.validate-release-request.outputs.release_tag }}
           path: release-assets/mac
 
       - name: Download Windows release assets
         if: needs.build-win.result == 'success'
         uses: actions/download-artifact@v8.0.1
         with:
-          name: release-windows-${{ steps.release_meta.outputs.release_tag }}
+          name: release-windows-${{ needs.validate-release-request.outputs.release_tag }}
           path: release-assets/win
 
       - name: Publish curated GitHub release assets
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-          RELEASE_TAG: ${{ steps.release_meta.outputs.release_tag }}
+          RELEASE_TAG: ${{ needs.validate-release-request.outputs.release_tag }}
+          MANUAL_RELEASE: ${{ github.event_name == 'workflow_dispatch' && 'true' || 'false' }}
         run: |
           assets=(release-assets/mac/* release-assets/win/*)
 
           if gh release view "$RELEASE_TAG" -R "$GH_REPO" >/dev/null 2>&1; then
+            if [ "$MANUAL_RELEASE" = "true" ]; then
+              is_draft="$(gh release view "$RELEASE_TAG" --json isDraft --jq '.isDraft' -R "$GH_REPO")"
+              if [ "$is_draft" != "true" ]; then
+                echo "::error::Manual recovery cannot replace an already-published release."
+                exit 1
+              fi
+            fi
             gh release upload "$RELEASE_TAG" "${assets[@]}" --clobber -R "$GH_REPO"
+          elif [ "$MANUAL_RELEASE" = "true" ]; then
+            gh release create "$RELEASE_TAG" "${assets[@]}" --draft --verify-tag --title "$RELEASE_TAG" -R "$GH_REPO"
           else
             gh release create "$RELEASE_TAG" "${assets[@]}" --verify-tag --title "$RELEASE_TAG" -R "$GH_REPO"
           fi
@@ -515,7 +616,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-          RELEASE_TAG: ${{ steps.release_meta.outputs.release_tag }}
+          RELEASE_TAG: ${{ needs.validate-release-request.outputs.release_tag }}
         run: |
           release_json="$(gh api "repos/${GH_REPO}/releases/tags/${RELEASE_TAG}")"
           blockmap_ids="$(jq -r '.assets[] | select(.name | endswith(".blockmap")) | .id' <<<"$release_json")"


### PR DESCRIPTION
## Summary

- restore a signed manual release path for an existing protected `v*` tag
- validate the requested tag and require its version to match `package.json`
- build the exact validated tag commit on both macOS and Windows
- create manual recovery releases as drafts for review before publication
- preserve normal tag-triggered releases and unsigned manual QA builds

## Root cause

The protected `v1.1.0` tag exists, but its push did not produce a GitHub Actions run. The previous manual signed-release fallback had been removed, so there was no safe way to recover without moving the approved tag.

## Safety

This changes only `.github/workflows/build.yml`; no application or packaging source changes.

Manual recovery:

- requires repository write access to dispatch
- requires `release_platform=all`
- accepts only an existing, version-shaped `v*` tag
- verifies the tag target and matching package version
- checks out the validated commit SHA for both platform builds
- refuses to overwrite an already-published release
- creates a draft release so notes and assets can be reviewed first

## Validation

- `actionlint v1.7.7 .github/workflows/build.yml`
- `git diff --check`
- verified `v1.1.0` resolves to `8fd73601a223a615c385395f4290c50ace13d355`
- verified the tagged `package.json` version is `1.1.0`

## After merge

Dispatch **Build & Release** from `main` with:

- `release_platform`: `all`
- `release_tag`: `v1.1.0`

The workflow will build and sign both platforms and create a draft GitHub release.
