### PR TITLE
Fix cleanup for draft release assets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -632,8 +632,10 @@ jobs:
           GH_REPO: ${{ github.repository }}
           RELEASE_TAG: ${{ needs.validate-release-request.outputs.release_tag }}
         run: |
-          release_json="$(gh api "repos/${GH_REPO}/releases/tags/${RELEASE_TAG}")"
-          blockmap_ids="$(jq -r '.assets[] | select(.name | endswith(".blockmap")) | .id' <<<"$release_json")"
+          blockmap_ids="$(
+            gh release view "$RELEASE_TAG" -R "$GH_REPO" --json assets \
+              --jq '.assets[] | select(.name | endswith(".blockmap")) | .apiUrl | split("/")[-1]'
+          )"
 
           if [ -z "$blockmap_ids" ]; then
             exit 0


### PR DESCRIPTION
## Summary

- query release assets through the draft-aware GitHub CLI release command
- preserve the existing blockmap deletion behavior
- avoid the REST tag lookup that returns 404 for draft releases

## Verification

- git diff --check
- ran the corrected asset query against the existing v1.1.0 draft; it completed successfully and confirmed there are no blockmap assets