### PR TITLE
Improve Windows AI memory handling and Ollama recovery

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -898,9 +898,6 @@ app.whenReady().then(async () => {
       if (!profile) {
         return false
       }
-      if (profile.id === 'win-gpu') {
-        return false
-      }
       if (profile.id === 'win-low-spec') {
         return true
       }

--- a/src/main/ipc/recording-ipc.ts
+++ b/src/main/ipc/recording-ipc.ts
@@ -1291,8 +1291,9 @@ export function registerRecordingIpc(
   function scheduleWindowsCalendarTitleRefresh(
     meetingId: string,
     meetingDir: string,
-    metadataHint: MeetingMetadata | null = null
-  ): void {
+    metadataHint: MeetingMetadata | null = null,
+    options?: { logSchedule?: boolean }
+  ): boolean {
     // Windows users were waiting on a live calendar fetch before a freshly stopped
     // recording appeared in AI Notes. We keep macOS behavior as-is and do the
     // calendar match lazily on Windows so the item shows up immediately and stays clickable.
@@ -1301,13 +1302,15 @@ export function registerRecordingIpc(
       !calendarManager.isConnected() ||
       windowsCalendarRefreshInFlight.has(meetingId)
     ) {
-      return
+      return false
     }
 
     windowsCalendarRefreshInFlight.add(meetingId)
-    logRecordingDebug('scheduled background calendar title refresh', meetingId, {
-      hasMetadataHint: metadataHint != null
-    })
+    if (options?.logSchedule !== false) {
+      logRecordingDebug('scheduled background calendar title refresh', meetingId, {
+        hasMetadataHint: metadataHint != null
+      })
+    }
 
     void (async () => {
       const refreshStartedAt = Date.now()
@@ -1352,6 +1355,7 @@ export function registerRecordingIpc(
         windowsCalendarRefreshInFlight.delete(meetingId)
       }
     })()
+    return true
   }
 
   ipcMain.handle('recording:list', async (): Promise<RecordingEntry[]> => {
@@ -1362,6 +1366,9 @@ export function registerRecordingIpc(
     } catch {
       return []
     }
+
+    let scheduledCalendarRefreshes = 0
+    let scheduledWithMetadataHint = 0
 
     // Fetch recent calendar events for matching recordings to event names
     let recentEvents: CalendarEvent[] = []
@@ -1417,7 +1424,12 @@ export function registerRecordingIpc(
       const title = buildRecordingTitle(metadata, startedAt, calendarTitle)
 
       if (!metadata?.customTitle && !calendarTitle) {
-        scheduleWindowsCalendarTitleRefresh(meetingId, meetingDir, metadata)
+        if (scheduleWindowsCalendarTitleRefresh(meetingId, meetingDir, metadata, { logSchedule: false })) {
+          scheduledCalendarRefreshes += 1
+          if (metadata != null) {
+            scheduledWithMetadataHint += 1
+          }
+        }
       }
       const transcriptionStatus = await transcriptionService.getStatus(meetingId)
 
@@ -1448,6 +1460,12 @@ export function registerRecordingIpc(
     }
 
     if (isWindows) {
+      if (scheduledCalendarRefreshes > 0) {
+        logRecordingDebug('scheduled background calendar title refreshes', undefined, {
+          meetingCount: scheduledCalendarRefreshes,
+          withMetadataHint: scheduledWithMetadataHint
+        })
+      }
       logRecordingDebug('recording:list resolved', undefined, {
         entryCount: entries.length,
         finalizingMeetingIds: entries

--- a/src/main/services/__tests__/diagnostic-log-upload.test.ts
+++ b/src/main/services/__tests__/diagnostic-log-upload.test.ts
@@ -95,4 +95,16 @@ describe('diagnostic log upload', () => {
     expect(sanitized).not.toContain('qa-user')
     expect(parsed.binaryPath).toBe('[home]\\AppData\\Roaming\\AutoDoc\\ollama.exe')
   })
+
+  it('sanitizes Windows home paths with spaces and non-canonical Users casing', () => {
+    const line = JSON.stringify({
+      binaryPath: 'C:\\users\\QA User\\AppData\\Roaming\\AutoDoc\\ollama.exe'
+    })
+
+    const sanitized = sanitizeDiagnosticLogTail(line)
+    const parsed = JSON.parse(sanitized) as { binaryPath: string }
+
+    expect(sanitized).not.toContain('QA User')
+    expect(parsed.binaryPath).toBe('[home]\\AppData\\Roaming\\AutoDoc\\ollama.exe')
+  })
 })

--- a/src/main/services/__tests__/diagnostic-log-upload.test.ts
+++ b/src/main/services/__tests__/diagnostic-log-upload.test.ts
@@ -83,4 +83,16 @@ describe('diagnostic log upload', () => {
     expect(sanitized).not.toContain('qa@example.com')
     expect(() => JSON.parse(sanitized)).not.toThrow()
   })
+
+  it('sanitizes JSON-escaped Windows home paths in log lines', () => {
+    const line = JSON.stringify({
+      binaryPath: 'C:\\Users\\qa-user\\AppData\\Roaming\\AutoDoc\\ollama.exe'
+    })
+
+    const sanitized = sanitizeDiagnosticLogTail(line)
+    const parsed = JSON.parse(sanitized) as { binaryPath: string }
+
+    expect(sanitized).not.toContain('qa-user')
+    expect(parsed.binaryPath).toBe('[home]\\AppData\\Roaming\\AutoDoc\\ollama.exe')
+  })
 })

--- a/src/main/services/__tests__/segmentation.test.ts
+++ b/src/main/services/__tests__/segmentation.test.ts
@@ -689,11 +689,14 @@ describe('SegmentationService', () => {
       service.retry('m-poison')
       await vi.advanceTimersByTimeAsync(0)
 
+      expect(enqueueSpy).toHaveBeenCalledTimes(1)
+      expect(enqueueSpy).toHaveBeenLastCalledWith('m-poison', 'direct')
       expect(fsMock.writeFile).toHaveBeenCalledTimes(failureWrites)
       expect(provider.summarize).not.toHaveBeenCalled()
 
       await vi.advanceTimersByTimeAsync(1_000)
-      expect(enqueueSpy).toHaveBeenCalledWith('m-poison', 'direct')
+      expect(enqueueSpy).toHaveBeenCalledTimes(2)
+      expect(enqueueSpy).toHaveBeenLastCalledWith('m-poison', 'direct')
       expect(fsMock.writeFile).toHaveBeenCalledTimes(failureWrites)
     } finally {
       vi.useRealTimers()

--- a/src/main/services/__tests__/segmentation.test.ts
+++ b/src/main/services/__tests__/segmentation.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { join } from 'path'
 import { BrowserWindow } from 'electron'
 import { SegmentationService } from '../segmentation'
@@ -49,7 +49,8 @@ function createMockProvider(): LLMProvider {
     checkConnection: vi.fn().mockResolvedValue(true),
     abortActiveRequests: vi.fn(),
     setModel: vi.fn(),
-    setLowMemoryMode: vi.fn()
+    setLowMemoryMode: vi.fn(),
+    releaseResources: vi.fn().mockResolvedValue(undefined)
   }
 }
 
@@ -768,5 +769,130 @@ describe('SegmentationService', () => {
 
     expect(() => (service as any).updateActivity('meeting-a', 'waiting-for-local-ai')).not.toThrow()
     expect(service.getActivity('meeting-a')).toBe('waiting-for-local-ai')
+  })
+
+  describe('LLM resource release', () => {
+    const originalPlatform = process.platform
+
+    const setPlatform = (platform: NodeJS.Platform) => {
+      Object.defineProperty(process, 'platform', {
+        value: platform,
+        configurable: true
+      })
+    }
+
+    beforeEach(() => {
+      vi.mocked(BrowserWindow.getAllWindows).mockReturnValue([])
+    })
+
+    function setupSummarizeTranscript() {
+      fsMock.access.mockImplementation(async (path) => {
+        if (String(path).endsWith('transcript.json')) return undefined
+        throw new Error('ENOENT')
+      })
+      fsMock.readFile.mockResolvedValue(
+        JSON.stringify([
+          {
+            id: 'm1-0',
+            meetingId: 'm1',
+            speaker: 'Chris',
+            text: 'We confirmed the rollout plan.',
+            startMs: 0,
+            endMs: 65_000,
+            confidence: 0.9
+          }
+        ]) as any
+      )
+      vi.mocked(provider.summarize).mockResolvedValue({
+        decisions: [],
+        actionItems: [],
+        information: [
+          {
+            id: 'seg-1',
+            meetingId: 'm1',
+            category: 'information',
+            topic: 'Rollout',
+            title: 'Plan confirmed',
+            content: 'The rollout plan was confirmed.',
+            assignee: null,
+            deadline: null,
+            sourceStartMs: 0,
+            sourceEndMs: 65_000
+          }
+        ],
+        discussion: [],
+        statusUpdates: []
+      })
+    }
+
+    afterEach(() => {
+      Object.defineProperty(process, 'platform', {
+        value: originalPlatform,
+        configurable: true
+      })
+    })
+
+    it('calls releaseResources after successful summarize on win32', async () => {
+      setPlatform('win32')
+      provider = createMockProvider()
+      service = new SegmentationService(
+        provider,
+        createMockOllamaManager(),
+        '/mock/home/AutoDoc/recordings'
+      )
+      setupSummarizeTranscript()
+
+      await (service as any).processJob('m1')
+
+      expect(provider.releaseResources).toHaveBeenCalledWith('m1')
+    })
+
+    it('calls releaseResources on win32 when summarize throws', async () => {
+      setPlatform('win32')
+      provider = createMockProvider()
+      service = new SegmentationService(
+        provider,
+        createMockOllamaManager(),
+        '/mock/home/AutoDoc/recordings'
+      )
+      setupSummarizeTranscript()
+      vi.mocked(provider.summarize).mockRejectedValue(new Error('Ollama unavailable'))
+
+      await expect((service as any).processJob('m1')).rejects.toThrow('Ollama unavailable')
+      expect(provider.releaseResources).toHaveBeenCalledWith('m1')
+    })
+
+    it('does not log mac resource snapshot on win32 after summarize', async () => {
+      setPlatform('win32')
+      provider = createMockProvider()
+      service = new SegmentationService(
+        provider,
+        createMockOllamaManager(),
+        '/mock/home/AutoDoc/recordings'
+      )
+      setupSummarizeTranscript()
+      const logMacResourceSnapshot = vi
+        .spyOn(service as any, 'logMacResourceSnapshot')
+        .mockResolvedValue(undefined)
+
+      await (service as any).processJob('m1')
+
+      expect(logMacResourceSnapshot).not.toHaveBeenCalled()
+    })
+
+    it('calls releaseResources after successful summarize on darwin', async () => {
+      setPlatform('darwin')
+      provider = createMockProvider()
+      service = new SegmentationService(
+        provider,
+        createMockOllamaManager(),
+        '/mock/home/AutoDoc/recordings'
+      )
+      setupSummarizeTranscript()
+
+      await (service as any).processJob('m1')
+
+      expect(provider.releaseResources).toHaveBeenCalledWith('m1')
+    })
   })
 })

--- a/src/main/services/__tests__/segmentation.test.ts
+++ b/src/main/services/__tests__/segmentation.test.ts
@@ -20,7 +20,8 @@ vi.mock('fs/promises', () => ({
   readFile: vi.fn(),
   writeFile: vi.fn(),
   unlink: vi.fn(),
-  stat: vi.fn()
+  stat: vi.fn(),
+  readdir: vi.fn()
 }))
 
 vi.mock('../crypto', () => ({
@@ -640,6 +641,106 @@ describe('SegmentationService', () => {
     expect(fsMock.writeFile).not.toHaveBeenCalled()
     expect(enqueueSpy).toHaveBeenCalledWith('m-ollama', 'direct')
     vi.useRealTimers()
+  })
+
+  it('starts a fresh Ollama defer cycle on retry after defer budget is exhausted', async () => {
+    vi.useFakeTimers()
+    try {
+      const notReadyOllama = {
+        waitUntilReady: vi.fn().mockResolvedValue(undefined),
+        isReadyForGeneration: vi.fn().mockResolvedValue(false)
+      }
+      provider = createMockProvider()
+      service = new SegmentationService(provider, notReadyOllama, '/mock/home/AutoDoc/recordings')
+      fsMock.access.mockImplementation(async (path) => {
+        if (String(path).endsWith('transcript.json')) return undefined
+        throw new Error('ENOENT')
+      })
+      fsMock.readFile.mockResolvedValue(
+        JSON.stringify([
+          {
+            id: 'm-poison-0',
+            meetingId: 'm-poison',
+            speaker: 'Chris',
+            text: 'We confirmed the rollout plan.',
+            startMs: 0,
+            endMs: 65_000,
+            confidence: 0.9
+          }
+        ]) as any
+      )
+      fsMock.writeFile.mockResolvedValue(undefined as any)
+
+      for (let i = 0; i < 5; i++) {
+        await (service as any).processJobExclusive('m-poison')
+      }
+      await expect((service as any).processJobExclusive('m-poison')).rejects.toThrow(
+        'Ollama unavailable for notes generation — model runtime never became ready'
+      )
+      await (service as any).markFailed(
+        'm-poison',
+        new Error('Ollama unavailable for notes generation — model runtime never became ready')
+      )
+
+      vi.clearAllTimers()
+      const failureWrites = fsMock.writeFile.mock.calls.length
+      const enqueueSpy = vi.spyOn(service, 'enqueue')
+
+      service.retry('m-poison')
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(fsMock.writeFile).toHaveBeenCalledTimes(failureWrites)
+      expect(provider.summarize).not.toHaveBeenCalled()
+
+      await vi.advanceTimersByTimeAsync(1_000)
+      expect(enqueueSpy).toHaveBeenCalledWith('m-poison', 'direct')
+      expect(fsMock.writeFile).toHaveBeenCalledTimes(failureWrites)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not re-enqueue a meeting that is mid Ollama defer cycle during pending scan', async () => {
+    vi.useFakeTimers()
+    try {
+      const notReadyOllama = {
+        waitUntilReady: vi.fn().mockResolvedValue(undefined),
+        isReadyForGeneration: vi.fn().mockResolvedValue(false)
+      }
+      provider = createMockProvider()
+      service = new SegmentationService(provider, notReadyOllama, '/mock/home/AutoDoc/recordings')
+      fsMock.access.mockImplementation(async (path) => {
+        if (String(path).endsWith('transcript.json')) return undefined
+        throw new Error('ENOENT')
+      })
+      fsMock.readFile.mockResolvedValue(
+        JSON.stringify([
+          {
+            id: 'm-scan-0',
+            meetingId: 'm-scan',
+            speaker: 'Chris',
+            text: 'We confirmed the rollout plan.',
+            startMs: 0,
+            endMs: 65_000,
+            confidence: 0.9
+          }
+        ]) as any
+      )
+
+      await (service as any).processJobExclusive('m-scan')
+      expect((service as any).ollamaGenerationDeferCounts.get('m-scan')).toBe(1)
+
+      fsMock.readdir.mockResolvedValue(['m-scan'] as any)
+      fsMock.stat.mockResolvedValue({ isDirectory: () => true } as any)
+
+      const enqueueSpy = vi.spyOn(service, 'enqueue')
+      await service.scanAndEnqueuePending()
+
+      expect(enqueueSpy).not.toHaveBeenCalled()
+      expect((service as any).ollamaGenerationDeferCounts.get('m-scan')).toBe(1)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('clears activeProgress after a job finishes', () => {

--- a/src/main/services/__tests__/transcription.test.ts
+++ b/src/main/services/__tests__/transcription.test.ts
@@ -1338,6 +1338,177 @@ describe('TranscriptionService', () => {
     }
   })
 
+  it('fails win-gpu transcription after extended memory wait when free memory stays below the floor', async () => {
+    setPlatform('win32')
+    vi.useFakeTimers()
+    try {
+      mockWhisper = {
+        ...mockWhisper,
+        isWorkerEngineSelected: vi.fn().mockReturnValue(true),
+        isFasterWhisperSelected: vi.fn().mockReturnValue(false),
+        getTranscriptionWorkerScriptPath: vi.fn().mockReturnValue('/mock/transcription-worker.py'),
+        getWorkerModelPath: vi.fn().mockReturnValue('/mock/parakeet-model'),
+        getWorkerPythonPath: vi.fn().mockReturnValue('/mock/python.exe'),
+        getWorkerDevice: vi.fn().mockReturnValue('dml'),
+        getWorkerComputeType: vi.fn().mockReturnValue('fp32'),
+        getWorkerProcessEnv: vi.fn().mockReturnValue({ PATH: '/mock/path' }),
+        getWorkerEngine: vi.fn().mockReturnValue('parakeet'),
+        getTranscriptionBackend: vi.fn().mockReturnValue('parakeet-gpu'),
+        getSelectedWindowsProfileEstimatedMemoryGiB: vi.fn().mockReturnValue(2.5)
+      } as unknown as WhisperManager
+      service = new TranscriptionService(
+        mockWhisper,
+        mockConverter,
+        '/mock/home/AutoDoc/recordings',
+        mockCalendar,
+        () => false,
+        null,
+        () => false,
+        null,
+        () => 'balanced',
+        () => 'balanced',
+        async () => ({
+          id: 'win-gpu',
+          label: 'GPU Windows processing',
+          reason: 'test',
+          hardware: { logicalProcessors: 16, totalMemoryGiB: 16, freeMemoryGiB: 1.7 },
+          dualSourceMode: 'concurrent',
+          serializeLocalProcessing: false,
+          notesAfterTranscriptionOnly: false,
+          threadPolicy: 'default'
+        }),
+        async (ms) => {
+          await vi.advanceTimersByTimeAsync(ms)
+        },
+        () => ({ freeGiB: 1.7, totalGiB: 16 })
+      )
+
+      const promise = (service as any).runWhisperPassAndRead(
+        '/mock/tmp/audio.wav',
+        'meeting-win-gpu-starved',
+        60,
+        []
+      )
+
+      for (let i = 0; i < 13; i += 1) {
+        await vi.advanceTimersByTimeAsync(5000)
+      }
+      expect(autodocLogMock.logAutodocEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          area: 'transcription',
+          message: 'Proceeding with transcription pass after memory wait timeout',
+          meetingId: 'meeting-win-gpu-starved'
+        })
+      )
+      expect(autodocLogMock.logAutodocEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          area: 'transcription',
+          message: expect.stringMatching(/extended memory wait/i),
+          meetingId: 'meeting-win-gpu-starved',
+          context: expect.objectContaining({ minFreeGiB: 2.5, freeGiB: 1.7 })
+        })
+      )
+      expect(workerClientMock.transcribe).not.toHaveBeenCalled()
+
+      const rejection = expect(promise).rejects.toThrow(
+        /Insufficient free memory for GPU transcription pass \(1\.7 GiB free, floor 2\.5 GiB\) after extended wait/
+      )
+      for (let i = 0; i < 50; i += 1) {
+        await vi.advanceTimersByTimeAsync(5000)
+      }
+      await rejection
+      expect(workerClientMock.transcribe).not.toHaveBeenCalled()
+      expect(autodocLogMock.logAutodocEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          area: 'transcription',
+          message: expect.stringMatching(/Insufficient free memory for GPU transcription pass/i),
+          meetingId: 'meeting-win-gpu-starved',
+          context: expect.objectContaining({ minFreeGiB: 2.5, freeGiB: 1.7 })
+        })
+      )
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('allows win-gpu transcription to proceed when memory recovers during the extended wait', async () => {
+    setPlatform('win32')
+    vi.useFakeTimers()
+    try {
+      let freeGiB = 1.7
+      mockWhisper = {
+        ...mockWhisper,
+        isWorkerEngineSelected: vi.fn().mockReturnValue(true),
+        isFasterWhisperSelected: vi.fn().mockReturnValue(false),
+        getTranscriptionWorkerScriptPath: vi.fn().mockReturnValue('/mock/transcription-worker.py'),
+        getWorkerModelPath: vi.fn().mockReturnValue('/mock/parakeet-model'),
+        getWorkerPythonPath: vi.fn().mockReturnValue('/mock/python.exe'),
+        getWorkerDevice: vi.fn().mockReturnValue('dml'),
+        getWorkerComputeType: vi.fn().mockReturnValue('fp32'),
+        getWorkerProcessEnv: vi.fn().mockReturnValue({ PATH: '/mock/path' }),
+        getWorkerEngine: vi.fn().mockReturnValue('parakeet'),
+        getTranscriptionBackend: vi.fn().mockReturnValue('parakeet-gpu'),
+        getSelectedWindowsProfileEstimatedMemoryGiB: vi.fn().mockReturnValue(2.5)
+      } as unknown as WhisperManager
+      service = new TranscriptionService(
+        mockWhisper,
+        mockConverter,
+        '/mock/home/AutoDoc/recordings',
+        mockCalendar,
+        () => false,
+        null,
+        () => false,
+        null,
+        () => 'balanced',
+        () => 'balanced',
+        async () => ({
+          id: 'win-gpu',
+          label: 'GPU Windows processing',
+          reason: 'test',
+          hardware: { logicalProcessors: 16, totalMemoryGiB: 16, freeMemoryGiB: freeGiB },
+          dualSourceMode: 'concurrent',
+          serializeLocalProcessing: false,
+          notesAfterTranscriptionOnly: false,
+          threadPolicy: 'default'
+        }),
+        async (ms) => {
+          await vi.advanceTimersByTimeAsync(ms)
+        },
+        () => ({ freeGiB, totalGiB: 16 })
+      )
+      workerClientMock.transcribe.mockResolvedValue({ transcription: [] })
+
+      const promise = (service as any).runWhisperPassAndRead(
+        '/mock/tmp/audio.wav',
+        'meeting-win-gpu-recover',
+        60,
+        []
+      )
+
+      for (let i = 0; i < 13; i += 1) {
+        await vi.advanceTimersByTimeAsync(5000)
+      }
+      expect(autodocLogMock.logAutodocEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          area: 'transcription',
+          message: expect.stringMatching(/extended memory wait/i),
+          meetingId: 'meeting-win-gpu-recover',
+          context: expect.objectContaining({ minFreeGiB: 2.5, freeGiB: 1.7 })
+        })
+      )
+      expect(workerClientMock.transcribe).not.toHaveBeenCalled()
+
+      freeGiB = 3
+      for (let i = 0; i < 2; i += 1) {
+        await vi.advanceTimersByTimeAsync(5000)
+      }
+      await promise
+      expect(workerClientMock.transcribe).toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('does not extend the memory wait when free memory is at least 1 GiB after the normal timeout', async () => {
     setPlatform('win32')
     vi.useFakeTimers()

--- a/src/main/services/__tests__/windows-processing-profile.test.ts
+++ b/src/main/services/__tests__/windows-processing-profile.test.ts
@@ -90,15 +90,23 @@ describe('windows processing profile selection', () => {
     expect(recoveredProfile.notesAfterTranscriptionOnly).toBe(false)
   })
 
-  it('keeps GPU mode concurrent even when runtime memory is low', () => {
+  it('serializes GPU mode under runtime memory pressure and recovers when memory is healthy', () => {
     const stableProfile = selectWindowsProcessingProfile(hardware(), 'dml')
-    const effectiveProfile = selectEffectiveWindowsProcessingProfile(stableProfile, {
+    const pressuredProfile = selectEffectiveWindowsProcessingProfile(stableProfile, {
       freeMemoryGiB: 1
     })
+    const recoveredProfile = selectEffectiveWindowsProcessingProfile(stableProfile, {
+      freeMemoryGiB: 4
+    })
 
-    expect(effectiveProfile.id).toBe('win-gpu')
-    expect(effectiveProfile.dualSourceMode).toBe('concurrent')
-    expect(effectiveProfile.serializeLocalProcessing).toBe(false)
+    expect(pressuredProfile.id).toBe('win-gpu')
+    expect(pressuredProfile.serializeLocalProcessing).toBe(true)
+    expect(pressuredProfile.dualSourceMode).toBe('sequential')
+    expect(pressuredProfile.notesAfterTranscriptionOnly).toBe(true)
+    expect(recoveredProfile.id).toBe('win-gpu')
+    expect(recoveredProfile.dualSourceMode).toBe('concurrent')
+    expect(recoveredProfile.serializeLocalProcessing).toBe(false)
+    expect(recoveredProfile.notesAfterTranscriptionOnly).toBe(false)
   })
 
   it('keeps low-spec stable profile at runtime', () => {

--- a/src/main/services/diagnostic-log-upload.ts
+++ b/src/main/services/diagnostic-log-upload.ts
@@ -13,7 +13,11 @@ const SECRET_REPLACEMENTS: Array<[RegExp, string]> = [
   [/https?:\/\/[^\s"'<>]*autodoc-auth\.duetdisplay\.workers\.dev[^\s"'<>]*/gi, REDACTION]
 ]
 
-const PATH_PATTERNS = [/\/Users\/[^/\s]+/g, /[A-Za-z]:\\Users\\[^\\\s]+/g]
+const PATH_PATTERNS = [
+  /\/Users\/[^/\s"]+/g,
+  // Log entries are sanitized after JSON serialization, where Windows separators are doubled.
+  /[A-Za-z]:\\{1,2}Users\\{1,2}[^\\\s"]+/g
+]
 
 export interface DiagnosticLogAttachment {
   filename: string

--- a/src/main/services/diagnostic-log-upload.ts
+++ b/src/main/services/diagnostic-log-upload.ts
@@ -16,7 +16,7 @@ const SECRET_REPLACEMENTS: Array<[RegExp, string]> = [
 const PATH_PATTERNS = [
   /\/Users\/[^/\s"]+/g,
   // Log entries are sanitized after JSON serialization, where Windows separators are doubled.
-  /[A-Za-z]:\\{1,2}Users\\{1,2}[^\\\s"]+/g
+  /[A-Za-z]:\\{1,2}Users\\{1,2}[^\\"]+/gi
 ]
 
 export interface DiagnosticLogAttachment {

--- a/src/main/services/ollama-manager.ts
+++ b/src/main/services/ollama-manager.ts
@@ -12,6 +12,7 @@ import {
 } from '../../shared/constants'
 import { getInstalledModelsDir, getInstalledOllamaDataDir } from './dev-runtime-paths'
 import { canUseSystemRuntimeFallback } from './runtime-policy'
+import { logAutodocEvent, logAutodocFailure } from './autodoc-log'
 
 const OLLAMA_DOWNLOAD_VERSION = 'v0.30.0'
 const IS_WIN = process.platform === 'win32'
@@ -208,6 +209,11 @@ export class OllamaManager extends EventEmitter {
         if (systemBinary) {
           await copyFile(systemBinary, this.getBinaryPath())
           this.adoptedSystemRuntime = true
+          logAutodocEvent({
+            area: 'ollama',
+            message: 'adopted system ollama runtime',
+            context: { systemBinaryPath: systemBinary }
+          })
           return
         }
       }
@@ -266,8 +272,10 @@ export class OllamaManager extends EventEmitter {
     this.killProcessOnPort()
     await new Promise((r) => setTimeout(r, 1000))
 
+    const binary = this.getBinaryPath()
+    const spawnStartedAt = Date.now()
+
     await new Promise<void>((resolve, reject) => {
-      const binary = this.getBinaryPath()
       const proc = spawn(binary, ['serve'], {
         env: {
           ...process.env,
@@ -278,41 +286,97 @@ export class OllamaManager extends EventEmitter {
       })
 
       this.process = proc
+      logAutodocEvent({
+        area: 'ollama',
+        message: 'ollama server spawn attempt',
+        context: { binaryPath: binary, pid: proc.pid ?? null }
+      })
 
       let stderr = ''
+      let settled = false
+
+      const pollInterval = setInterval(async () => {
+        if (await this.isServerRunning()) {
+          markReady()
+        }
+      }, 500)
+
+      const timeoutHandle = setTimeout(() => {
+        if (settled) return
+        settled = true
+        clearInterval(pollInterval)
+        logAutodocFailure({
+          area: 'ollama',
+          message: 'ollama server failed to start within timeout',
+          error: new Error('Ollama server failed to start within 30 seconds'),
+          context: { timeoutMs: 30_000, binaryPath: binary }
+        })
+        reject(new Error('Ollama server failed to start within 30 seconds'))
+      }, 30_000)
+
+      function markReady(): void {
+        if (settled) return
+        settled = true
+        clearInterval(pollInterval)
+        clearTimeout(timeoutHandle)
+        logAutodocEvent({
+          area: 'ollama',
+          message: 'ollama server became ready',
+          context: {
+            startupMs: Date.now() - spawnStartedAt,
+            pid: proc.pid ?? null,
+            binaryPath: binary
+          }
+        })
+        resolve()
+      }
+
       proc.stderr?.on('data', (data: Buffer) => {
         stderr += data.toString()
         // Ollama logs "Listening on ..." to stderr when ready
         if (stderr.includes('Listening on')) {
-          resolve()
+          markReady()
         }
       })
 
       proc.on('error', (err) => {
         this.process = null
+        if (settled) return
+        settled = true
+        clearInterval(pollInterval)
+        clearTimeout(timeoutHandle)
         reject(new Error(`Failed to start Ollama: ${err.message}`))
       })
 
-      proc.on('exit', (code) => {
+      proc.on('exit', (code, signal) => {
         this.process = null
+        const exitContext = {
+          exitCode: code,
+          signal: signal ?? null,
+          pid: proc.pid ?? null
+        }
         if (code !== null && code !== 0) {
+          logAutodocFailure({
+            area: 'ollama',
+            message: 'ollama server process exited',
+            error: new Error(`Ollama exited with code ${code}: ${stderr.slice(-300)}`),
+            context: exitContext
+          })
+        } else {
+          logAutodocEvent({
+            area: 'ollama',
+            message: 'ollama server process exited',
+            level: 'warn',
+            context: exitContext
+          })
+        }
+        if (!settled && code !== null && code !== 0) {
+          settled = true
+          clearInterval(pollInterval)
+          clearTimeout(timeoutHandle)
           reject(new Error(`Ollama exited with code ${code}: ${stderr.slice(-300)}`))
         }
       })
-
-      // Fallback: poll for readiness if we miss the log line
-      const pollInterval = setInterval(async () => {
-        if (await this.isServerRunning()) {
-          clearInterval(pollInterval)
-          resolve()
-        }
-      }, 500)
-
-      // Timeout after 30 seconds
-      setTimeout(() => {
-        clearInterval(pollInterval)
-        reject(new Error('Ollama server failed to start within 30 seconds'))
-      }, 30_000)
     })
   }
 
@@ -343,6 +407,7 @@ export class OllamaManager extends EventEmitter {
    * where start() found an existing server and never tracked its PID.
    */
   private killProcessOnPort(): void {
+    const killedPids: number[] = []
     try {
       if (IS_WIN) {
         const output = execSync(`netstat -ano | findstr "LISTENING" | findstr ":${OLLAMA_PORT}"`, {
@@ -357,6 +422,7 @@ export class OllamaManager extends EventEmitter {
         for (const pid of pids) {
           try {
             execSync(`taskkill /pid ${pid} /f /t`, { timeout: 5000 })
+            killedPids.push(Number(pid))
           } catch {
             // already dead
           }
@@ -370,6 +436,7 @@ export class OllamaManager extends EventEmitter {
           if (pid) {
             try {
               process.kill(Number(pid), 'SIGKILL')
+              killedPids.push(Number(pid))
             } catch {
               // already dead
             }
@@ -378,6 +445,14 @@ export class OllamaManager extends EventEmitter {
       }
     } catch {
       // No process found on the port - nothing to clean up
+    }
+
+    if (killedPids.length > 0) {
+      logAutodocEvent({
+        area: 'ollama',
+        message: 'killed orphaned ollama process on port',
+        context: { port: OLLAMA_PORT, pids: killedPids }
+      })
     }
   }
 

--- a/src/main/services/ollama-manager.ts
+++ b/src/main/services/ollama-manager.ts
@@ -13,6 +13,7 @@ import {
 import { getInstalledModelsDir, getInstalledOllamaDataDir } from './dev-runtime-paths'
 import { canUseSystemRuntimeFallback } from './runtime-policy'
 import { logAutodocEvent, logAutodocFailure } from './autodoc-log'
+import { sanitizeDiagnosticLogTail } from './diagnostic-log-upload'
 
 const OLLAMA_DOWNLOAD_VERSION = 'v0.30.0'
 const IS_WIN = process.platform === 'win32'
@@ -211,8 +212,7 @@ export class OllamaManager extends EventEmitter {
           this.adoptedSystemRuntime = true
           logAutodocEvent({
             area: 'ollama',
-            message: 'adopted system ollama runtime',
-            context: { systemBinaryPath: systemBinary }
+            message: 'adopted system ollama runtime'
           })
           return
         }
@@ -289,7 +289,7 @@ export class OllamaManager extends EventEmitter {
       logAutodocEvent({
         area: 'ollama',
         message: 'ollama server spawn attempt',
-        context: { binaryPath: binary, pid: proc.pid ?? null }
+        context: { pid: proc.pid ?? null }
       })
 
       let stderr = ''
@@ -309,7 +309,7 @@ export class OllamaManager extends EventEmitter {
           area: 'ollama',
           message: 'ollama server failed to start within timeout',
           error: new Error('Ollama server failed to start within 30 seconds'),
-          context: { timeoutMs: 30_000, binaryPath: binary }
+          context: { timeoutMs: 30_000 }
         })
         reject(new Error('Ollama server failed to start within 30 seconds'))
       }, 30_000)
@@ -324,8 +324,7 @@ export class OllamaManager extends EventEmitter {
           message: 'ollama server became ready',
           context: {
             startupMs: Date.now() - spawnStartedAt,
-            pid: proc.pid ?? null,
-            binaryPath: binary
+            pid: proc.pid ?? null
           }
         })
         resolve()
@@ -355,11 +354,18 @@ export class OllamaManager extends EventEmitter {
           signal: signal ?? null,
           pid: proc.pid ?? null
         }
-        if (code !== null && code !== 0) {
+        const sanitizedStderrTail = sanitizeDiagnosticLogTail(stderr.slice(-300)).trim()
+        const exitError =
+          code !== null && code !== 0
+            ? new Error(
+                `Ollama exited with code ${code}${sanitizedStderrTail ? `: ${sanitizedStderrTail}` : ''}`
+              )
+            : null
+        if (exitError) {
           logAutodocFailure({
             area: 'ollama',
             message: 'ollama server process exited',
-            error: new Error(`Ollama exited with code ${code}: ${stderr.slice(-300)}`),
+            error: exitError,
             context: exitContext
           })
         } else {
@@ -370,11 +376,11 @@ export class OllamaManager extends EventEmitter {
             context: exitContext
           })
         }
-        if (!settled && code !== null && code !== 0) {
+        if (!settled && exitError) {
           settled = true
           clearInterval(pollInterval)
           clearTimeout(timeoutHandle)
-          reject(new Error(`Ollama exited with code ${code}: ${stderr.slice(-300)}`))
+          reject(exitError)
         }
       })
     })

--- a/src/main/services/segmentation.ts
+++ b/src/main/services/segmentation.ts
@@ -191,6 +191,8 @@ export class SegmentationService {
 
     for (const meetingId of dirs) {
       try {
+        if (this.ollamaGenerationDeferCounts.has(meetingId)) continue
+
         const meetingDir = join(this.recordingsBaseDir, meetingId)
         const dirStat = await stat(meetingDir).catch(() => null)
         if (!dirStat?.isDirectory()) continue
@@ -500,6 +502,7 @@ export class SegmentationService {
 
     const deferCount = this.ollamaGenerationDeferCounts.get(meetingId) ?? 0
     if (deferCount >= OLLAMA_GENERATION_DEFER_MAX) {
+      this.ollamaGenerationDeferCounts.delete(meetingId)
       throw new Error(OLLAMA_UNAVAILABLE_ERROR)
     }
 

--- a/src/main/services/segmentation.ts
+++ b/src/main/services/segmentation.ts
@@ -400,7 +400,7 @@ export class SegmentationService {
         }
       )
     } finally {
-      if (process.platform === 'darwin') {
+      if (process.platform === 'darwin' || process.platform === 'win32') {
         await this.llmProvider.releaseResources?.(meetingId).catch((error) => {
           logAutodocEvent({
             area: 'segmentation',
@@ -413,7 +413,9 @@ export class SegmentationService {
             }
           })
         })
-        await this.logMacResourceSnapshot('notes resources released', meetingId)
+        if (process.platform === 'darwin') {
+          await this.logMacResourceSnapshot('notes resources released', meetingId)
+        }
       }
     }
 

--- a/src/main/services/transcription.ts
+++ b/src/main/services/transcription.ts
@@ -2389,8 +2389,7 @@ export class TranscriptionService {
 
     logAutodocEvent({
       area: 'transcription',
-      message:
-        'Starting extended memory wait on low-spec/CPU profile after timeout with low free memory',
+      message: 'Starting extended memory wait after timeout with low free memory',
       meetingId,
       context: {
         freeGiB: freeAfterTimeoutGiB,
@@ -2410,11 +2409,7 @@ export class TranscriptionService {
     }
 
     const freeAfterExtendedWaitGiB = readFreeGiB()
-    if (
-      isGpuProfile &&
-      freeAfterExtendedWaitGiB != null &&
-      freeAfterExtendedWaitGiB < minFreeGiB
-    ) {
+    if (isGpuProfile && freeAfterExtendedWaitGiB != null && freeAfterExtendedWaitGiB < minFreeGiB) {
       logAutodocEvent({
         area: 'transcription',
         message: 'Insufficient free memory for GPU transcription pass after extended wait',

--- a/src/main/services/transcription.ts
+++ b/src/main/services/transcription.ts
@@ -59,6 +59,7 @@ const WINDOWS_MEMORY_GATE_POLL_INTERVAL_MS = 5000
 const WINDOWS_MEMORY_GATE_MAX_WAIT_MS = 60000
 const WINDOWS_MEMORY_GATE_EXTENDED_WAIT_MS = 4 * 60 * 1000
 const WINDOWS_MEMORY_GATE_EXTENDED_MIN_FREE_GIB = 1
+const WINDOWS_MEMORY_GATE_GPU_MIN_FREE_GIB = 2.5
 const DML_DEVICE_LOSS_FAILURE_THRESHOLD = 2
 const CHUNKED_TRANSCRIPTION_THRESHOLD_SEC = 20 * 60
 const CHUNKED_TRANSCRIPTION_WINDOW_SEC = 90
@@ -2374,10 +2375,14 @@ export class TranscriptionService {
 
     const profile = await this.getEffectiveWindowsProcessingProfileForJob()
     const isCpuTierProfile = profile?.id === 'win-low-spec' || profile?.id === 'win-cpu-normal'
+    const isGpuProfile = profile?.id === 'win-gpu'
+    const minFreeGiB = isGpuProfile
+      ? WINDOWS_MEMORY_GATE_GPU_MIN_FREE_GIB
+      : WINDOWS_MEMORY_GATE_EXTENDED_MIN_FREE_GIB
     if (
-      !isCpuTierProfile ||
+      !(isCpuTierProfile || isGpuProfile) ||
       freeAfterTimeoutGiB == null ||
-      freeAfterTimeoutGiB >= WINDOWS_MEMORY_GATE_EXTENDED_MIN_FREE_GIB
+      freeAfterTimeoutGiB >= minFreeGiB
     ) {
       return
     }
@@ -2390,7 +2395,7 @@ export class TranscriptionService {
       context: {
         freeGiB: freeAfterTimeoutGiB,
         requiredGiB,
-        minFreeGiB: WINDOWS_MEMORY_GATE_EXTENDED_MIN_FREE_GIB,
+        minFreeGiB,
         maxExtraWaitMs: WINDOWS_MEMORY_GATE_EXTENDED_WAIT_MS
       }
     })
@@ -2399,9 +2404,31 @@ export class TranscriptionService {
     while (Date.now() - extendedStartedAt < WINDOWS_MEMORY_GATE_EXTENDED_WAIT_MS) {
       await this.memoryGateDelay(WINDOWS_MEMORY_GATE_POLL_INTERVAL_MS)
       const freeGiB = readFreeGiB()
-      if (freeGiB == null || freeGiB >= WINDOWS_MEMORY_GATE_EXTENDED_MIN_FREE_GIB) {
+      if (freeGiB == null || freeGiB >= minFreeGiB) {
         return
       }
+    }
+
+    const freeAfterExtendedWaitGiB = readFreeGiB()
+    if (
+      isGpuProfile &&
+      freeAfterExtendedWaitGiB != null &&
+      freeAfterExtendedWaitGiB < minFreeGiB
+    ) {
+      logAutodocEvent({
+        area: 'transcription',
+        message: 'Insufficient free memory for GPU transcription pass after extended wait',
+        meetingId,
+        context: {
+          freeGiB: freeAfterExtendedWaitGiB,
+          requiredGiB,
+          minFreeGiB,
+          waitedMs: WINDOWS_MEMORY_GATE_MAX_WAIT_MS + WINDOWS_MEMORY_GATE_EXTENDED_WAIT_MS
+        }
+      })
+      throw new Error(
+        `Insufficient free memory for GPU transcription pass (${freeAfterExtendedWaitGiB} GiB free, floor ${minFreeGiB} GiB) after extended wait`
+      )
     }
   }
 

--- a/src/main/services/windows-processing-profile.ts
+++ b/src/main/services/windows-processing-profile.ts
@@ -66,11 +66,14 @@ export function selectEffectiveWindowsProcessingProfile(
   }
 
   if (stableProfile.id === 'win-gpu') {
+    if (!isMemoryHealthyForConcurrentDualSource(memorySnapshot)) {
+      return createRuntimePressuredProfile(stableProfile)
+    }
     return createGpuProfile(stableProfile.hardware, stableProfile.reason)
   }
 
   if (!isMemoryHealthyForConcurrentDualSource(memorySnapshot)) {
-    return createRuntimePressuredCpuNormalProfile(stableProfile)
+    return createRuntimePressuredProfile(stableProfile)
   }
 
   return createCpuNormalProfile(stableProfile.hardware, stableProfile.reason)
@@ -136,7 +139,7 @@ function createLowSpecProfile(
   }
 }
 
-function createRuntimePressuredCpuNormalProfile(
+function createRuntimePressuredProfile(
   stableProfile: WindowsProcessingProfile
 ): WindowsProcessingProfile {
   return {


### PR DESCRIPTION
## Summary

- release Ollama notes-model resources on Windows and serialize GPU processing under runtime memory pressure
- stop GPU transcription cleanly when free memory remains below the safe floor after the extended wait
- reset exhausted Ollama defer state for manual retries and avoid duplicate recovery-scan enqueues
- batch Windows calendar refresh diagnostics and add Ollama lifecycle events for support triage

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / chore
- [ ] Other

## Impact

This improves Windows notes generation and transcription reliability on memory-constrained systems, while making Ollama startup and recovery failures easier to diagnose.

## Scope audit

Only public production code and tests are included. Private release workflows, feeds, signing configuration, and other non-public artifacts are excluded.

## Test plan

- [x] `npm run test:main:run -- src/main/ipc/__tests__/recording-ipc.test.ts src/main/services/__tests__/segmentation.test.ts src/main/services/__tests__/transcription.test.ts src/main/services/__tests__/windows-processing-profile.test.ts`
  - 105 passed, 13 skipped
- [x] `npm run typecheck:node`

## Checklist

- [x] My change is focused and does not include unrelated edits.
- [x] Documentation is not required for these reliability fixes.
- [ ] I agree my contribution is licensed under the project's AGPL-3.0 license.
