### PR TITLE
Prepare AutoDoc 1.1.2 release metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "autodoc",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "autodoc",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "hasInstallScript": true,
       "license": "AGPL-3.0-only",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autodoc",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Local-first meeting assistant",
   "license": "AGPL-3.0-only",
   "main": "./out/main/index.js",


### PR DESCRIPTION
## Summary

- update the application version from 1.1.1 to 1.1.2
- keep package.json and package-lock.json release metadata aligned

## Why

The v1.1.2 tag-triggered release correctly started after the GitHub Actions disruption, but release validation rejected the tagged commit because its package metadata still reported 1.1.1.

## Validation

- verified package.json version is 1.1.2
- verified package-lock.json root versions are 1.1.2
- git diff --check