### PR TITLE
1.1.3: document 8 GB Windows notes experience and remove leftover Email Us text

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ Transcription is built on [MLX](https://github.com/ml-explore/mlx) and requires 
 
 On lower-spec Windows PCs, AutoDoc uses a CPU-optimized Parakeet model and processes audio sources sequentially. This reduces memory pressure but can take longer after a meeting ends.
 
+**What to expect on an 8 GB Windows PC:** AutoDoc still generates notes locally with `llama3.1`. That uses a lot of RAM while notes are running, so transcription and notes take longer and the machine will feel pinned until they finish. A 16 GB machine is the comfortable default.
+
 ### Download & install on macOS
 
 <div align="center">
@@ -258,7 +260,7 @@ On Windows, AutoDoc uses Parakeet TDT 0.6B v3 and automatically selects DirectML
 An **Apple Silicon Mac** (M1 or later) running macOS 14+, with 8 GB RAM minimum (16 GB recommended) and ~10 GB free storage for first-run model downloads. **Intel Macs are not supported.**
 
 **Is Windows supported?**
-Yes. AutoDoc supports 64-bit Windows 10 and later. It requires 8 GB RAM; 16 GB is recommended. A compatible DirectML GPU is optional because AutoDoc can transcribe on the CPU.
+Yes. AutoDoc supports 64-bit Windows 10 and later. It requires 8 GB RAM; 16 GB is recommended. On 8 GB machines, notes take longer and use more RAM while they run. A compatible DirectML GPU is optional because AutoDoc can transcribe on the CPU.
 
 **How do I know AutoDoc is recording?**
 While recording, AutoDoc shows a Recording banner in the app (with a timer and stop control) and switches the menu bar / tray icon to a recording state. Meeting detection only offers to start recording; it will not start silently unless you previously enabled calendar auto-record for that event (Once or Series). In that case, recording can begin without another prompt.

--- a/src/renderer/src/components/Sidebar.test.tsx
+++ b/src/renderer/src/components/Sidebar.test.tsx
@@ -71,8 +71,9 @@ describe('Sidebar', () => {
 
     await waitFor(() => {
       expect(window.electronAPI.invoke).toHaveBeenCalledWith('support:open-email', 'sidebar')
-      expect(screen.getByText('Draft opened in your email app.')).toBeInTheDocument()
     })
+    expect(screen.queryByText('Draft opened in your email app.')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Email Us' })).toBeEnabled()
     expect(trackEventMock).toHaveBeenCalledWith('support_email_requested', {
       surface: 'sidebar'
     })

--- a/src/renderer/src/components/Sidebar.tsx
+++ b/src/renderer/src/components/Sidebar.tsx
@@ -135,7 +135,7 @@ export function Sidebar() {
     trackEvent('support_email_requested', { surface: SUPPORT_SURFACE })
     try {
       const result = await window.electronAPI.invoke('support:open-email', SUPPORT_SURFACE)
-      setSupportResult(result)
+      setSupportResult(result.status === 'opened' ? null : result)
       trackEvent('support_email_outcome', {
         surface: SUPPORT_SURFACE,
         outcome:
@@ -286,9 +286,7 @@ export function Sidebar() {
           </button>
 
           <div aria-live="polite" className="px-2.5 text-[10.5px] leading-4 text-ink-faint">
-            {supportResult?.status === 'opened' ? (
-              <p>Draft opened in your email app.</p>
-            ) : supportResult?.status === 'copy-required' ? (
+            {supportResult?.status === 'copy-required' ? (
               <div className="flex flex-col items-start gap-1">
                 <p>Mail app didn’t open.</p>
                 <span className="break-all select-text text-ink-muted">

--- a/src/renderer/src/components/onboarding/OnboardingSupportLink.test.tsx
+++ b/src/renderer/src/components/onboarding/OnboardingSupportLink.test.tsx
@@ -60,11 +60,14 @@ describe('OnboardingSupportLink', () => {
 
     resolveOpen?.({ status: 'opened' })
 
-    expect(await screen.findByText('Draft opened in your email app.')).toBeInTheDocument()
-    expect(trackEvent).toHaveBeenCalledWith('support_email_outcome', {
-      surface: 'onboarding',
-      outcome: 'draft_opened'
+    await waitFor(() => {
+      expect(trackEvent).toHaveBeenCalledWith('support_email_outcome', {
+        surface: 'onboarding',
+        outcome: 'draft_opened'
+      })
     })
+    expect(screen.queryByText('Draft opened in your email app.')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Email Us' })).toBeEnabled()
   })
 
   it('copies through main when an email app cannot be opened', async () => {

--- a/src/renderer/src/components/onboarding/OnboardingSupportLink.tsx
+++ b/src/renderer/src/components/onboarding/OnboardingSupportLink.tsx
@@ -24,8 +24,6 @@ export function OnboardingSupportLink() {
       </div>
 
       <div id={STATUS_ID} aria-live="polite" aria-atomic="true" className="min-h-4 leading-4">
-        {result?.status === 'opened' ? <p>Draft opened in your email app.</p> : null}
-
         {result?.status === 'copy-required' ? (
           <div className="flex flex-wrap items-center justify-center gap-x-1.5 gap-y-0.5">
             <span>Mail app didn’t open.</span>

--- a/src/renderer/src/hooks/useSupportEmail.ts
+++ b/src/renderer/src/hooks/useSupportEmail.ts
@@ -56,8 +56,13 @@ export function useSupportEmail(surface: SupportEmailSurface): SupportEmailState
 
     try {
       const nextResult = await window.electronAPI.invoke('support:open-email', surface)
-      resultRef.current = nextResult
-      setResult(nextResult)
+      if (nextResult.status === 'opened') {
+        resultRef.current = null
+        setResult(null)
+      } else {
+        resultRef.current = nextResult
+        setResult(nextResult)
+      }
       trackEvent('support_email_outcome', {
         surface,
         outcome:


### PR DESCRIPTION
## Summary

Documents the real 8 GB Windows notes experience and stops the leftover Email Us confirmation after the mail client opens.

8 GB remains the Windows minimum. This does not change models, timeouts, or Mac behavior. On 8 GB Windows, notes still run locally with `llama3.1`; they use more RAM, take longer, and the machine will feel pinned until they finish. 16 GB stays the comfortable default.

Clicking **Email Us** now just opens the default mail client. The persistent “Draft opened in your email app.” status is gone from the sidebar and onboarding. The copy-address fallback still appears if a mail client does not open.

The same FAQ wording is already live on getautodoc.com.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactor / chore
- [ ] Other (describe below)

## Test plan

- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [x] `npm run test:run` — matching Email Us unit tests passed on the internal repo (`Sidebar` + `OnboardingSupportLink`, 21 tests). Public files were the same change.
- [x] Other: review README Windows requirements + FAQ line; click Email Us and confirm no leftover success text; confirm copy fallback still shows if mail does not open.

## Checklist

- [x] My change is focused and does not include unrelated edits.
- [x] I updated documentation if behavior changed.
- [x] I agree my contribution is licensed under the project's [AGPL-3.0 license](../LICENSE).